### PR TITLE
fix compile errors with visual c++ 2015

### DIFF
--- a/binder/binder.cpp
+++ b/binder/binder.cpp
@@ -123,12 +123,12 @@ public:
 
 	virtual bool VisitFunctionDecl(FunctionDecl *F)
 	{
-		if( F->isCXXInstanceMember() or isa<CXXMethodDecl>(F) ) return true;
+		if( F->isCXXInstanceMember() || isa<CXXMethodDecl>(F) ) return true;
 
 		if( binder::is_bindable(F) ) {
 			binder::BinderOP b = std::make_shared<binder::FunctionBinder>(F);
 			context.add(b);
-		} else if( F->isOverloadedOperator()  and  F->getNameAsString() == "operator<<" ) {
+		} else if( F->isOverloadedOperator()  &&  F->getNameAsString() == "operator<<" ) {
 			//outs() << "Adding insertion operator: " << binder::function_pointer_type(F) << "\n";
 			context.add_insertion_operator(F);
 		}
@@ -137,7 +137,7 @@ public:
     }
 
 	virtual bool VisitCXXRecordDecl(CXXRecordDecl *C) {
-		if( C->isCXXInstanceMember()  or  C->isCXXClassMember() ) return true;
+		if( C->isCXXInstanceMember()  ||  C->isCXXClassMember() ) return true;
 
 		if( binder::is_bindable(C) ) {
 			binder::BinderOP b = std::make_shared<binder::ClassBinder>(C);
@@ -187,7 +187,7 @@ public:
 	// }
 
 	virtual bool VisitEnumDecl(EnumDecl *E) {
-		if( E->isCXXInstanceMember()  or  E->isCXXClassMember() ) return true;
+		if( E->isCXXInstanceMember()  ||  E->isCXXClassMember() ) return true;
 
 		binder::BinderOP b = std::make_shared<binder::EnumBinder>( E/*->getCanonicalDecl()*/ );
 		context.add(b);

--- a/binder/config.cpp
+++ b/binder/config.cpp
@@ -73,7 +73,7 @@ void Config::read(string const &file_name)
 		if( line.size() ) {
 			if( line[0] == '#' ) continue;
 
-			if( line[0] == '+'  or  line[0] == '-' ) {
+			if( line[0] == '+'  ||  line[0] == '-' ) {
 				size_t space = line.find(' ');
 				if(  space == string::npos ) throw std::runtime_error("Invalid line in config file! Each line must have token separated with space from object name. For example: '+function aaa::bb::my_function'. Line: " + line);
 				else {
@@ -154,7 +154,7 @@ bool Config::is_namespace_binding_requested(string const &namespace_) const
 	if( to_bind.size() > to_skip.size() ) return true;
 	if( to_bind.size() < to_skip.size() ) return false;
 
-	if( to_bind_flag and to_skip_flag ) throw std::runtime_error("Could not determent if namespace '" + namespace_ + "' should be binded or not... please check if options --bind and --skip conflicting!!!");
+	if( to_bind_flag && to_skip_flag ) throw std::runtime_error("Could not determent if namespace '" + namespace_ + "' should be binded or not... please check if options --bind and --skip conflicting!!!");
 
 	if( to_bind_flag ) return true;
 
@@ -181,7 +181,7 @@ bool Config::is_namespace_skipping_requested(string const &namespace_) const
 	if( to_bind.size() > to_skip.size() ) return false;
 	if( to_bind.size() < to_skip.size() ) return true;
 
-	if( to_bind_flag and to_skip_flag ) throw std::runtime_error("Could not determent if namespace '" + namespace_ + "' should be binded or not... please check if options --bind and --skip conflicting!!!");
+	if( to_bind_flag && to_skip_flag ) throw std::runtime_error("Could not determent if namespace '" + namespace_ + "' should be binded or not... please check if options --bind and --skip conflicting!!!");
 
 	if( to_skip_flag ) return true;
 

--- a/binder/context.cpp
+++ b/binder/context.cpp
@@ -45,7 +45,7 @@ namespace binder {
 // check if declaration is already in stack with level at lease as 'level' or lower and add it if it is not - return true if declaration was added
 bool IncludeSet::add_decl(clang::NamedDecl const *D, int level)
 {
-	if( stack_.count(D)  and  stack_[D] <= level ) return false;
+	if( stack_.count(D)  &&  stack_[D] <= level ) return false;
 
 	stack_[D] = level;
 	return true;
@@ -74,7 +74,7 @@ bool Binder::is_in_system_header()
 // return true if code was already generate for this object
 bool Binder::is_binded() const
 {
-	return code().size()  or is_python_builtin( named_decl() );
+	return code().size()  || is_python_builtin( named_decl() );
 }
 
 
@@ -123,7 +123,7 @@ clang::FunctionDecl const * Context::global_insertion_operator(clang::CXXRecordD
 /// check if forward declaration for CXXRecordDecl needed
 bool Context::is_forward_needed(CXXRecordDecl const *C)
 {
-	return !binded.count( class_qualified_name(C) )  and  !is_python_builtin(C);
+	return !binded.count( class_qualified_name(C) )  &&  !is_python_builtin(C);
 }
 
 
@@ -177,7 +177,7 @@ std::string Context::module_variable_name(std::string const& namespace_)
 // find binder related to given object name and bind it
 void Context::request_bindings(std::string const &type)
 {
-	if( types.count(type)  and  !types[type]->is_binded()  and  types[type]->bindable()  and  !types[type]->skipping_requested()  and  !is_python_builtin( types[type]->named_decl() ) ) {
+	if( types.count(type)  &&  !types[type]->is_binded()  &&  types[type]->bindable()  &&  !types[type]->skipping_requested()  &&  !is_python_builtin( types[type]->named_decl() ) ) {
 		types[type]->request_bindings();
 	}
 }
@@ -188,7 +188,7 @@ void Context::bind(Config const &config)
 {
 	for(auto & sp : binders) {
 		Binder & b( *sp );
-		if( !b.is_in_system_header() and  b.bindable() ) b.request_bindings_and_skipping(config);
+		if( !b.is_in_system_header() &&  b.bindable() ) b.request_bindings_and_skipping(config);
 	}
 
 	bool flag = true;
@@ -200,7 +200,7 @@ void Context::bind(Config const &config)
 
 		for(auto & sp : binders) {
 			Binder & b( *sp );
-			if( !b.is_binded()  and  b.bindable() and  b.binding_requested() ) {
+			if( !b.is_binded()  &&  b.bindable() &&  b.binding_requested() ) {
 				//outs() << "Binding: " << b.id() /*named_decl()->getQualifiedNameAsString()*/ << "\n";
 				b.bind(*this);
 				flag=true;
@@ -262,7 +262,7 @@ string file_name_prefix_for_binder(BinderOP &b)
 	if( include.size() <= 2 ) { include = "<unknown/unknown.hh>";  outs() << "Warning: file_name_for_decl could not determent file name for decl: " + string(*b) + ", result is too short!\n"; } //throw std::runtime_error( "file_name_for_decl failed!!! include name for decl: " + string(*b) + " is too short!");
 	include = include.substr(1, include.size()-2);
 
-	if( namespace_from_named_decl(decl) == "std"  or  begins_with(namespace_from_named_decl(decl), "std::" ) ) include = "std/" +  ( begins_with(include, "bits/") ? include.substr(5) : include );
+	if( namespace_from_named_decl(decl) == "std"  ||  begins_with(namespace_from_named_decl(decl), "std::" ) ) include = "std/" +  ( begins_with(include, "bits/") ? include.substr(5) : include );
 
 	replace(include, ".hh", ""); replace(include, ".hpp", ""); replace(include, ".h", ""); replace(include, ".", "_");
 	return include;
@@ -319,7 +319,7 @@ void Context::generate(Config const &config)
 	sort_binders();
 
 	outs() << "Writing code...\n";
-	for(uint i=0; i<binders.size(); ++i) {
+	for(unsigned int i=0; i<binders.size(); ++i) {
 		if( /*binders[i]->is_binded()  and*/  binders[i]->code().size() ) {
 			string np = file_name_prefix_for_binder(binders[i]);
 			string file_name = np + ( file_names[np] ? "_"+std::to_string(file_names[np]) : "" );
@@ -339,7 +339,7 @@ void Context::generate(Config const &config)
 			//std::set<NamedDecl const *> stack;
 			IncludeSet includes;
 
-			for(; code.size()<config.maximum_file_length  and  i<binders.size()  and  namespace_==namespace_from_named_decl( binders[i]->named_decl() ); ++i) {
+			for(; code.size()<config.maximum_file_length  &&  i<binders.size()  &&  namespace_==namespace_from_named_decl( binders[i]->named_decl() ); ++i) {
 				//outs() << "Binding: " << string(*binders[i]) << "\n";
 				// if( ClassBinder * CB = dynamic_cast<ClassBinder*>( binders[i].get() ) ) {
 				// 	std::vector<clang::CXXRecordDecl const *> const dependencies = CB->dependencies();

--- a/binder/enum.cpp
+++ b/binder/enum.cpp
@@ -66,7 +66,7 @@ string EnumBinder::id() const
 /// check if generator can create binding
 bool EnumBinder::bindable() const
 {
-	if( E->isCXXInstanceMember()  or  E->isCXXClassMember() ) return false;
+	if( E->isCXXInstanceMember()  ||  E->isCXXClassMember() ) return false;
 	else return true;
 }
 

--- a/binder/function.cpp
+++ b/binder/function.cpp
@@ -64,7 +64,7 @@ string function_arguments(clang::FunctionDecl const *record)
 {
 	string r;
 
-	for(uint i=0; i<record->getNumParams(); ++i) {
+	for(unsigned int i=0; i<record->getNumParams(); ++i) {
 		r += record->getParamDecl(i)->getOriginalType().getCanonicalType().getAsString();
 		if( i+1 != record->getNumParams() ) r += ", ";
 	}
@@ -78,17 +78,17 @@ string function_arguments(clang::FunctionDecl const *record)
 // Generate function argument list separate by comma
 // name_arguments - if arguments should be named: a1, a2, ...
 // n - number of arguments to generate. If n > num_of_function_parameters - generate only list with num_of_function_parameters
-pair<string, string> function_arguments_for_lambda(clang::FunctionDecl const *record, uint n)
+pair<string, string> function_arguments_for_lambda(clang::FunctionDecl const *record, unsigned int n)
 {
 	string r, a;
 
-	for(uint i=0; i<record->getNumParams()  and  i<n; ++i) {
+	for(unsigned int i=0; i<record->getNumParams()  &&  i<n; ++i) {
 		QualType qt = record->getParamDecl(i)->getOriginalType().getCanonicalType();
 		r += qt.getAsString() + ' ';
-		if( !qt->isReferenceType()  and  !qt->isPointerType() ) r += !qt.isConstQualified() ? " const &" : " &";
+		if( !qt->isReferenceType()  &&  !qt->isPointerType() ) r += !qt.isConstQualified() ? " const &" : " &";
 		r += "a" + std::to_string(i);
 		a += "a" + std::to_string(i);
-		if( i+1 != record->getNumParams()  and  i+1 != n ) { r += ", ";  a += ", "; }
+		if( i+1 != record->getNumParams()  &&  i+1 != n ) { r += ", ";  a += ", "; }
 	}
 
 	fix_boolean_types(r);
@@ -103,7 +103,7 @@ tuple<string, string, string> function_arguments_for_py_overload(clang::Function
 {
 	string r, a, p;
 
-	for(uint i=0; i<record->getNumParams(); ++i) {
+	for(unsigned int i=0; i<record->getNumParams(); ++i) {
 		QualType qt = record->getParamDecl(i)->getOriginalType().getCanonicalType();
 		r += qt.getAsString() + ' ' + "a" + std::to_string(i);
 		a += "a" + std::to_string(i);
@@ -122,10 +122,10 @@ string template_specialization(FunctionDecl const *F)
 {
 	string templ;
 
-	if( F->getTemplatedKind() == FunctionDecl::TK_MemberSpecialization  or   F->getTemplatedKind() == FunctionDecl::TK_FunctionTemplateSpecialization ) {
+	if( F->getTemplatedKind() == FunctionDecl::TK_MemberSpecialization  ||   F->getTemplatedKind() == FunctionDecl::TK_FunctionTemplateSpecialization ) {
 		if( TemplateArgumentList const *ta = F->getTemplateSpecializationArgs() ) {
 			templ += "<";
-			for(uint i=0; i < ta->size(); ++i) {
+			for(unsigned int i=0; i < ta->size(); ++i) {
 				//outs() << "function template argument: " << template_argument_to_string( ta->get(i) ) << "\n";
 				templ += template_argument_to_string( ta->get(i) ) + ",";
 
@@ -195,11 +195,11 @@ vector<QualType> get_type_dependencies(FunctionDecl const *F)
 	vector<QualType> r;
 
 	r.push_back( F->getReturnType() ); //.getDesugaredType(F->getASTContext()) );
-	for(uint i=0; i<F->getNumParams(); ++i) r.push_back(F->getParamDecl(i)->getOriginalType()/*.getDesugaredType(F->getASTContext())*/ );
+	for(unsigned int i=0; i<F->getNumParams(); ++i) r.push_back(F->getParamDecl(i)->getOriginalType()/*.getDesugaredType(F->getASTContext())*/ );
 
-	if( F->getTemplatedKind() == FunctionDecl::TK_MemberSpecialization  or   F->getTemplatedKind() == FunctionDecl::TK_FunctionTemplateSpecialization ) {
+	if( F->getTemplatedKind() == FunctionDecl::TK_MemberSpecialization  ||   F->getTemplatedKind() == FunctionDecl::TK_FunctionTemplateSpecialization ) {
 		if( TemplateArgumentList const *tal = F->getTemplateSpecializationArgs() ) {
-			for(uint i=0; i < tal->size(); ++i) {
+			for(unsigned int i=0; i < tal->size(); ++i) {
 				TemplateArgument const &ta( tal->get(i) );
 				if( ta.getKind() == TemplateArgument::Type ) r.push_back( ta.getAsType() );
 			}
@@ -213,7 +213,7 @@ vector<QualType> get_type_dependencies(FunctionDecl const *F)
 /// check if user requested binding for the given declaration
 bool is_binding_requested(FunctionDecl const *F, Config const &config)
 {
-	bool bind = config.is_function_binding_requested( F->getQualifiedNameAsString() ) or  config.is_function_binding_requested( function_qualified_name(F) )  or  config.is_namespace_binding_requested( namespace_from_named_decl(F) );
+	bool bind = config.is_function_binding_requested( F->getQualifiedNameAsString() ) ||  config.is_function_binding_requested( function_qualified_name(F) )  ||  config.is_namespace_binding_requested( namespace_from_named_decl(F) );
 
 	for(auto & t : get_type_dependencies(F) ) bind |= binder::is_binding_requested(t, config);
 
@@ -225,7 +225,7 @@ bool is_binding_requested(FunctionDecl const *F, Config const &config)
 bool is_skipping_requested(FunctionDecl const *F, Config const &config)
 {
 	string name = standard_name( F->getQualifiedNameAsString() );
-	bool skip = config.is_function_skipping_requested(name) or config.is_function_skipping_requested( function_qualified_name(F) ) or config.is_namespace_skipping_requested( namespace_from_named_decl(F) );
+	bool skip = config.is_function_skipping_requested(name) || config.is_function_skipping_requested( function_qualified_name(F) ) || config.is_namespace_skipping_requested( namespace_from_named_decl(F) );
 
     // moved to config -> name.erase(std::remove(name.begin(), name.end(), ' '), name.end());
 	skip |= config.is_function_skipping_requested(name);
@@ -248,13 +248,13 @@ bool is_skipping_requested(FunctionDecl const *F, Config const &config)
 
 
 // Generate binding for given function: .def("foo", (std::string (aaaa::A::*)(int) ) &aaaa::A::foo, "doc")
-string bind_function(FunctionDecl const *F, uint args_to_bind, bool request_bindings_f, Context &context)
+string bind_function(FunctionDecl const *F, unsigned int args_to_bind, bool request_bindings_f, Context &context)
 {
 	string function_name = python_function_name(F);
 	string function_qualified_name { standard_name(F->getQualifiedNameAsString()) };
 
 	CXXMethodDecl const * m = dyn_cast<CXXMethodDecl>(F);
-	string maybe_static = m and m->isStatic() ? "_static" : "";
+	string maybe_static = m && m->isStatic() ? "_static" : "";
 
 	string function, documentation;
 	if( args_to_bind == F->getNumParams() ) {
@@ -262,7 +262,7 @@ string bind_function(FunctionDecl const *F, uint args_to_bind, bool request_bind
 
 		documentation = generate_documentation_string_for_declaration(F);
 		if( documentation.size() ) documentation += "\\n\\n";
-		documentation += "C++: " + F->getQualifiedNameAsString() + "(" + function_arguments(F) + ')' + (m  and  m->isConst() ? " const" : "") + " --> " + standard_name( F->getReturnType().getCanonicalType().getAsString() );
+		documentation += "C++: " + F->getQualifiedNameAsString() + "(" + function_arguments(F) + ')' + (m  &&  m->isConst() ? " const" : "") + " --> " + standard_name( F->getReturnType().getCanonicalType().getAsString() );
 	}
 	else {
 		pair<string, string> args = function_arguments_for_lambda(F, args_to_bind);
@@ -270,7 +270,7 @@ string bind_function(FunctionDecl const *F, uint args_to_bind, bool request_bind
 
 		string return_type = standard_name( F->getReturnType().getCanonicalType().getAsString() );
 
-		if( m and !m->isStatic() ) {
+		if( m && !m->isStatic() ) {
 			string object = class_qualified_name( m->getParent() ) + (m->isConst() ? " const" : "") + " &o" + ( args_to_bind ? ", " : "" );
 			function = "[]({}{}) -> {} {{ return o.{}({}); }}"_format(object, args.first, return_type, F->getNameAsString(), args.second);
 		}
@@ -280,7 +280,7 @@ string bind_function(FunctionDecl const *F, uint args_to_bind, bool request_bind
 	}
 
 	string maybe_return_policy = "";
-	if( m  and  !m->isStatic() ) {
+	if( m  &&  !m->isStatic() ) {
 		if     ( F->getReturnType()->isPointerType() )         maybe_return_policy = ", " + Config::get().default_member_pointer_return_value_policy();
 		else if( F->getReturnType()->isLValueReferenceType() ) maybe_return_policy = ", " + Config::get().default_member_lvalue_reference_return_value_policy();
 		else if( F->getReturnType()->isRValueReferenceType() ) maybe_return_policy = ", " + Config::get().default_member_rvalue_reference_return_value_policy();
@@ -295,7 +295,7 @@ string bind_function(FunctionDecl const *F, uint args_to_bind, bool request_bind
 
 	if(request_bindings_f) request_bindings(F->getReturnType().getCanonicalType(), context);
 
-	for(uint i=0; i<F->getNumParams()  and  i < args_to_bind; ++i) {
+	for(unsigned int i=0; i<F->getNumParams()  &&  i < args_to_bind; ++i) {
 		r += ", pybind11::arg(\"{}\")"_format( string( F->getParamDecl(i)->getName() ) );
 
 		if(request_bindings_f) request_bindings( F->getParamDecl(i)->getOriginalType(), context);
@@ -350,10 +350,10 @@ bool is_bindable(FunctionDecl const *F)
 
 	if( F->isOverloadedOperator() ) {
 		//outs() << "Operator: " << F->getNameAsString() << '\n';
-		if( !isa<CXXMethodDecl>(F)  or  !cpp_python_operator_map.count( F->getNameAsString() ) ) return false;
+		if( !isa<CXXMethodDecl>(F)  ||  !cpp_python_operator_map.count( F->getNameAsString() ) ) return false;
 	}
 
-	r &= F->getTemplatedKind() != FunctionDecl::TK_FunctionTemplate  /*and  !F->isOverloadedOperator()*/  and  !isa<CXXConversionDecl>(F)  and  !F->isDeleted();
+	r &= F->getTemplatedKind() != FunctionDecl::TK_FunctionTemplate  /*&&  !F->isOverloadedOperator()*/  &&  !isa<CXXConversionDecl>(F)  &&  !F->isDeleted();
 
 	QualType rt( F->getReturnType() );
 

--- a/binder/function.hpp
+++ b/binder/function.hpp
@@ -30,7 +30,7 @@ std::string function_arguments(clang::FunctionDecl const *record);
 // Generate function argument list separate by comma
 // name_arguments - if arguments should be named: a1, a2, ...
 // n - number of arguments to generate. If n > num_of_function_parameters - generate only list with num_of_function_parameters
-std::pair<std::string, std::string> function_arguments_for_lambda(clang::FunctionDecl const *record, uint n);
+std::pair<std::string, std::string> function_arguments_for_lambda(clang::FunctionDecl const *record, unsigned int n);
 
 
 // Generate function argument list with types separate by comma and with only arguments names

--- a/binder/type.cpp
+++ b/binder/type.cpp
@@ -74,14 +74,14 @@ string relevant_include(NamedDecl const *decl)
 	if( include.isValid() ) {
 		char const *data = sm.getCharacterData(include);
 
-		if( strlen(data) > 2  and  (*data == '"' or  *data == '<') ) {  // should be at least 3 chars: open/close symbol + file name
+		if( strlen(data) > 2  &&  (*data == '"' ||  *data == '<') ) {  // should be at least 3 chars: open/close symbol + file name
 			char terminator = *data == '"' ? '"' : '>';
 
 			include_string.push_back(*data); ++data;
-			for(; *data and  *data != terminator; ++data ) include_string.push_back(*data);
+			for(; *data &&  *data != terminator; ++data ) include_string.push_back(*data);
 			if(*data == terminator) include_string.push_back(*data);
 		}
-		if( include_string.size()  and  include_string[0]=='"' ) include_string.resize(0); // avoid adding include in quotes because compiler will not be able to find them
+		if( include_string.size()  &&  include_string[0]=='"' ) include_string.resize(0); // avoid adding include in quotes because compiler will ! be able to find them
 	}
 
 	return include_string;
@@ -195,17 +195,17 @@ bool is_bindable(QualType const &qt)
 {
 	bool r = true;
 
-	r &= !qt->isFunctionPointerType()  and  !qt->isRValueReferenceType()  and  !qt->isInstantiationDependentType()  and  !qt->isArrayType();  //and  !qt->isConstantArrayType()  and  !qt->isIncompleteArrayType()  and  !qt->isVariableArrayType()  and  !qt->isDependentSizedArrayType()
+	r &= !qt->isFunctionPointerType()  &&  !qt->isRValueReferenceType()  &&  !qt->isInstantiationDependentType()  &&  !qt->isArrayType();  //&&  !qt->isConstantArrayType()  &&  !qt->isIncompleteArrayType()  &&  !qt->isVariableArrayType()  &&  !qt->isDependentSizedArrayType()
 
 	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) {
 		QualType pqt = pt->getPointeeType();
 
 		if( pqt->isPointerType() ) return false;  // refuse to bind 'value**...' types
 		//if( pqt->isArithmeticType() ) return false;  // refuse to bind 'int*, doublle*...' types
-		if( pqt->isArrayType() or pqt->isConstantArrayType() ) return false;  // refuse to bind 'T* v[]...' types
+		if( pqt->isArrayType() || pqt->isConstantArrayType() ) return false;  // refuse to bind 'T* v[]...' types
 
 		string pqt_name = pqt.getAsString();
-		if( begins_with(pqt_name, "struct std::pair")  or  begins_with(pqt_name, "struct std::tuple") ) return false;  // but we allow bindings for 'const std::tuple' and 'const std::pair'
+		if( begins_with(pqt_name, "struct std::pair")  ||  begins_with(pqt_name, "struct std::tuple") ) return false;  // but we allow bindings for 'const std::tuple' && 'const std::pair'
 		//qt->dump();
 		r &= is_bindable( pt->getPointeeType()/*.getCanonicalType()*/ );
 	}
@@ -216,7 +216,7 @@ bool is_bindable(QualType const &qt)
 
 		// special handling for std::pair&  and  std::tuple&  whitch pybind11 can't pass by refference
 		string pqt_name = standard_name( pqt.getAsString() );
-		if( begins_with(pqt_name, "struct std::pair")  or  begins_with(pqt_name, "struct std::tuple") ) return false;  // but we allow bindings for 'const std::tuple' and 'const std::pair'
+		if( begins_with(pqt_name, "struct std::pair")  ||  begins_with(pqt_name, "struct std::tuple") ) return false;  // but we allow bindings for 'const std::tuple' && 'const std::pair'
 
 		//rt->dump();
 		//outs() << "Ref " << qt.getAsString() << " -> " << is_bindable( rt->getPointeeType().getCanonicalType() ) << "\n";
@@ -229,7 +229,7 @@ bool is_bindable(QualType const &qt)
 			r &= is_bindable(rd);
 		}
 		if( TagDecl *td = tp->getAsTagDecl() ) {
-			if( td->getAccess() == AS_protected  or  td->getAccess() == AS_private  ) return false;
+			if( td->getAccess() == AS_protected  ||  td->getAccess() == AS_private  ) return false;
 		}
 	}
 
@@ -244,7 +244,7 @@ void request_bindings(clang::QualType const &qt, Context &context)
 	if( /*is_bindable(qt)  and*/  !is_skipping_requested(qt, Config::get()) ) {
 		//outs() << "request_bindings(clang::QualType,...): " << qt.getAsString() << "\n";
 		if( TagDecl *td = qt->getAsTagDecl() ) {
-			if( td->isCompleteDefinition()  or  dyn_cast<ClassTemplateSpecializationDecl>(td) ) context.request_bindings( typename_from_type_decl(td) );
+			if( td->isCompleteDefinition()  ||  dyn_cast<ClassTemplateSpecializationDecl>(td) ) context.request_bindings( typename_from_type_decl(td) );
 		}
 
 		if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) {

--- a/binder/util.cpp
+++ b/binder/util.cpp
@@ -21,6 +21,7 @@
 #include <clang/AST/Comment.h>
 
 //#include <experimental/filesystem>
+#include <cctype>
 #include <cstdlib>
 #include <fstream>
 
@@ -38,7 +39,7 @@ vector<string> split(string const &buffer, string const & separator)
 	string line;
 	vector<string> lines;
 
-	for(uint i=0; i<buffer.size(); ++i) {
+	for(unsigned int i=0; i<buffer.size(); ++i) {
 		if( buffer.compare(i, separator.size(), separator) ) line.push_back( buffer[i] );
 		else {
 			lines.push_back(line);
@@ -162,8 +163,8 @@ void fix_boolean_types(string &type)
 	string B("_Bool");
 	size_t i = 0;
 	while( ( i = type.find(B, i) ) != string::npos ) {
-		if( ( i==0  or ( !std::isalpha(type[i-1]) and  !std::isdigit(type[i-1]) ) ) and
-			( i+B.size() == type.size()  or ( !std::isalpha(type[i+B.size()]) and  !std::isdigit(type[i+B.size()]) ) ) ) type.replace(i, B.size(), "bool");
+		if( ( i==0  || ( !std::isalpha(type[i-1]) &&  !std::isdigit(type[i-1]) ) ) &&
+			( i+B.size() == type.size()  || ( !std::isalpha(type[i+B.size()]) &&  !std::isdigit(type[i+B.size()]) ) ) ) type.replace(i, B.size(), "bool");
 		++i;
 	}
 }
@@ -219,13 +220,13 @@ string mangle_type_name(string const &name, bool mark_template)
 	bool template_ = false;
 
 	for(auto & c : name) {
-		if(c!=' '  and  c!='<'  and  c!='>'  and  c!=','  and  c!=':') { r.push_back(c); mangle=false; }
+		if(c!=' '  &&  c!='<'  &&  c!='>'  &&  c!=','  &&  c!=':') { r.push_back(c); mangle=false; }
 		else if(!mangle) { mangle = true; r.push_back('_'); }
 
-		if( c=='<'  or  c=='>'  or  c==',') template_ = true;
+		if( c=='<'  ||  c=='>'  ||  c==',') template_ = true;
 	}
 
-	if(template_ and mark_template) r.push_back('t');
+	if(template_ && mark_template) r.push_back('t');
 	return r;
 }
 
@@ -276,8 +277,8 @@ std::string generate_documentation_string_for_declaration(clang::Decl const* dec
 
 		text = get_text(comment, sm, SourceLocation());
 
-		uint i=0;
-		for(; i<text.size()  and  (text[i]==' ' or text[i]=='\n'); ++i) {}
+		unsigned int i=0;
+		for(; i<text.size()  &&  (text[i]==' ' || text[i]=='\n'); ++i) {}
 		if(i) text = text.substr(i);
 
 		//replace(text, "\n\n\n", "\n");


### PR DESCRIPTION
With the following changes, I was able to compile binder on windows 7 x64 with VC2015:
add <cctype> include
replace and/or/not keywords by &&/||/!
replace uint by unsigned int