### PR TITLE
enum include should also reference definition headers

### DIFF
--- a/binder/enum.cpp
+++ b/binder/enum.cpp
@@ -36,6 +36,8 @@ void add_relevant_includes(clang::EnumDecl const *E, IncludeSet &includes, int l
 {
 	if( !includes.add_decl(E, level) ) return;
 	add_relevant_include_for_decl(E, includes);
+
+	add_relevant_include_for_decl(E->getDefinition(), includes);
 }
 
 


### PR DESCRIPTION
The reasoning is that we are using the alternative values of the values in the generated code, not just the declaration