### PR TITLE
Add support for per-class includes.

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -87,6 +87,14 @@ Config file directives:
   -include <boost/format/internals.hpp>
   +include <python/PyRosetta/binder/stl_binders.hpp>
 
+* ``include_for_class``, directive to control C++ include directives on a per-class basis. Force Binder to add particular include
+  into generated source files when a given target class is present. This allows the inclusion of custom binding code, which may
+  then be referenced with either ``+binder`` or ``+add_on_binder`` directives.
+
+.. code-block:: bash
+
+  +include_for_class example::class <example/class_binding.hpp>
+
 
 * ``binder``, specify custom binding function for particular concreate or template class. In the example below all
   specializations of tempalte std::vector will be handled by ``binder::vector_binder`` function. For template classes binder

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -408,6 +408,16 @@ void ClassBinder::request_bindings_and_skipping(Config const &config)
 /// extract include needed for this generator and add it to includes vector
 void ClassBinder::add_relevant_includes(IncludeSet &includes) const
 {
+	string const qualified_name_without_template = standard_name( C->getQualifiedNameAsString() );
+	std::map<string, std::vector<string>> const &per_class_includes= Config::get().per_class_includes();
+
+	if( per_class_includes.count(qualified_name_without_template) ) {
+		for(auto i : per_class_includes.at(qualified_name_without_template))
+		{
+			includes.add_include(i);
+		}
+	}
+
 	for(auto & m : prefix_includes ) binder::add_relevant_includes(m, includes, 0);
 	binder::add_relevant_includes(C, includes, 0);
 

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -10,6 +10,7 @@
 /// @brief  Binding generation for C++ struct and class objects
 /// @author Sergey Lyskov
 
+#include <binder.hpp>
 #include <class.hpp>
 #include <function.hpp>
 #include <enum.hpp>
@@ -414,7 +415,8 @@ void ClassBinder::add_relevant_includes(IncludeSet &includes) const
 	auto pci = per_class_includes.find(qualified_name_without_template);
 	if(pci != per_class_includes.end()) {
 		for(auto const & i : pci->second) {
-			includes.add_include(i);
+			if(O_annotate_includes) includes.add_include(i + " // +include_for_class");
+			else includes.add_include(i);
 		}
 	}
 

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -410,10 +410,10 @@ void ClassBinder::add_relevant_includes(IncludeSet &includes) const
 {
 	string const qualified_name_without_template = standard_name( C->getQualifiedNameAsString() );
 	std::map<string, std::vector<string>> const &per_class_includes= Config::get().per_class_includes();
-
-	if( per_class_includes.count(qualified_name_without_template) ) {
-		for(auto i : per_class_includes.at(qualified_name_without_template))
-		{
+	
+	auto pci = per_class_includes.find(qualified_name_without_template);
+	if(pci != per_class_includes.end()) {
+		for(auto const & i : pci->second) {
 			includes.add_include(i);
 		}
 	}

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -55,6 +55,7 @@ void Config::read(string const &file_name)
 	string const _function_      {"function"};
 	string const _class_         {"class"};
 	string const _include_       {"include"};
+	string const _include_for_class_       {"include_for_class"};
 	string const _binder_        {"binder"};
 	string const _add_on_binder_ {"add_on_binder"};
 
@@ -101,6 +102,16 @@ void Config::read(string const &file_name)
 
 						if(bind) includes_to_add.push_back(name_without_spaces);
 						else includes_to_skip.push_back(name_without_spaces);
+
+					} else if( token == _include_for_class_ ) {
+
+						if(bind) {
+							auto class_and_include = split_in_two(name, "Invalid line for include_for_class specification! Must be: name_of_type + <space or tab> + include_path. Got: " + line);
+							per_class_includes_[class_and_include.first].push_back(class_and_include.second);
+						}
+						else {
+							throw std::runtime_error("include_for_class must be '+' configuration.");
+						}
 
 					} else if( token == _binder_ ) {
 

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -31,6 +31,7 @@ class Config
 
 private:
 	std::map<string, string> binders_, add_on_binders_;
+	std::map<string, std::vector<string>> per_class_includes_;
 
 	string default_static_pointer_return_value_policy_          = "pybind11::return_value_policy::automatic";
 	string default_static_lvalue_reference_return_value_policy_ = "pybind11::return_value_policy::automatic";
@@ -54,6 +55,7 @@ public:
 
 	std::map<string, string> const &binders() const { return binders_; }
 	std::map<string, string> const &add_on_binders() const { return add_on_binders_; }
+	std::map<string, std::vector<string>> const &per_class_includes () const { return per_class_includes_; }
 
 	string const &default_static_pointer_return_value_policy()          { return default_static_pointer_return_value_policy_; }
 	string const &default_static_lvalue_reference_return_value_policy() { return default_static_lvalue_reference_return_value_policy_; }

--- a/test/T31.include_for_class.config
+++ b/test/T31.include_for_class.config
@@ -1,0 +1,1 @@
++include_for_class bbbb::B <T31.include_for_class.incl.b.extra.include>

--- a/test/T31.include_for_class.hpp
+++ b/test/T31.include_for_class.hpp
@@ -1,0 +1,12 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+//
+// Copyright (c) 2016 Sergey Lyskov <sergey.lyskov@jhu.edu>
+//
+// All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+#pragma once
+
+#include <T31.include_for_class.incl.a.include>
+#include <T31.include_for_class.incl.b.include>

--- a/test/T31.include_for_class.incl.a.include
+++ b/test/T31.include_for_class.incl.a.include
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace aaaa
+{
+
+class A {};
+
+}

--- a/test/T31.include_for_class.incl.b.extra.include
+++ b/test/T31.include_for_class.incl.b.extra.include
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace bbbb
+{
+
+}

--- a/test/T31.include_for_class.incl.b.include
+++ b/test/T31.include_for_class.incl.b.include
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace bbbb
+{
+
+class B
+{};
+
+}

--- a/test/T31.include_for_class.ref
+++ b/test/T31.include_for_class.ref
@@ -23,7 +23,7 @@ void bind_T31_include_for_class_incl_a_include(std::function< pybind11::module &
 
 
 // File: T31_include_for_class_incl_b_include.cpp
-#include <T31.include_for_class.incl.b.extra.include>
+#include <T31.include_for_class.incl.b.extra.include> // +include_for_class
 #include <T31.include_for_class.incl.b.include> // bbbb::B
 #include <sstream> // __str__
 

--- a/test/T31.include_for_class.ref
+++ b/test/T31.include_for_class.ref
@@ -1,0 +1,93 @@
+// File: T31_include_for_class_incl_a_include.cpp
+#include <T31.include_for_class.incl.a.include> // aaaa::A
+#include <sstream> // __str__
+
+#include <pybind11/pybind11.h>
+
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+	#define BINDER_PYBIND11_TYPE_CASTER
+	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*);
+	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>);
+#endif
+
+void bind_T31_include_for_class_incl_a_include(std::function< pybind11::module &(std::string const &namespace_) > &M)
+{
+	{ // aaaa::A file:T31.include_for_class.incl.a.include line:6
+		pybind11::class_<aaaa::A, std::shared_ptr<aaaa::A>> cl(M("aaaa"), "A", "");
+		pybind11::handle cl_type = cl;
+
+		cl.def(pybind11::init<>());
+	}
+}
+
+
+// File: T31_include_for_class_incl_b_include.cpp
+#include <T31.include_for_class.incl.b.extra.include>
+#include <T31.include_for_class.incl.b.include> // bbbb::B
+#include <sstream> // __str__
+
+#include <pybind11/pybind11.h>
+
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+	#define BINDER_PYBIND11_TYPE_CASTER
+	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*);
+	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>);
+#endif
+
+void bind_T31_include_for_class_incl_b_include(std::function< pybind11::module &(std::string const &namespace_) > &M)
+{
+	{ // bbbb::B file:T31.include_for_class.incl.b.include line:6
+		pybind11::class_<bbbb::B, std::shared_ptr<bbbb::B>> cl(M("bbbb"), "B", "");
+		pybind11::handle cl_type = cl;
+
+		cl.def(pybind11::init<>());
+	}
+}
+
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <functional>
+
+#include <pybind11/pybind11.h>
+
+typedef std::function< pybind11::module & (std::string const &) > ModuleGetter;
+
+void bind_T31_include_for_class_incl_a_include(std::function< pybind11::module &(std::string const &namespace_) > &M);
+void bind_T31_include_for_class_incl_b_include(std::function< pybind11::module &(std::string const &namespace_) > &M);
+
+
+PYBIND11_PLUGIN(T31_include_for_class) {
+	std::map <std::string, std::shared_ptr<pybind11::module> > modules;
+	ModuleGetter M = [&](std::string const &namespace_) -> pybind11::module & {
+		auto it = modules.find(namespace_);
+		if( it == modules.end() ) throw std::runtime_error("Attempt to access pybind11::module for namespace " + namespace_ + " before it was created!!!");
+		return * it->second;
+	};
+
+	modules[""] = std::make_shared<pybind11::module>("T31_include_for_class", "T31_include_for_class module");
+
+	std::vector< std::pair<std::string, std::string> > sub_modules {
+		{"", "aaaa"},
+		{"", "bbbb"},
+	};
+	for(auto &p : sub_modules ) modules[p.first.size() ? p.first+"::"+p.second : p.second] = std::make_shared<pybind11::module>( modules[p.first]->def_submodule(p.second.c_str(), ("Bindings for " + p.first + "::" + p.second + " namespace").c_str() ) );
+
+	//pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
+
+	bind_T31_include_for_class_incl_a_include(M);
+	bind_T31_include_for_class_incl_b_include(M);
+
+	return modules[""]->ptr();
+}
+
+// Source list file: TEST/T31_include_for_class.sources
+// T31_include_for_class.cpp
+// T31_include_for_class_incl_a_include.cpp
+// T31_include_for_class_incl_b_include.cpp
+
+// Modules list file: TEST/T31_include_for_class.modules
+// aaaa bbbb 


### PR DESCRIPTION
Add support for per-class includes to binding generator.  Adding
"include_for_class" option to binder, which triggers inclusion of a
header on a class-specific basis. This features supports the definition
of per-class custom binding code in a standalone header, which may then
be referenced via the +binder option.