### PR TITLE
Add support for call guards in function invocations.

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -144,6 +144,8 @@ Config file directives:
 * ``default_member_rvalue_reference_return_value_policy``, specify return value policy for member functions returning r-value reference. Default
   is 'pybind11::return_value_policy::automatic'.
 
+* ``default_call_guard``, optionally specify a call guard applied to all function definitions. Default None
+
 
 
 
@@ -153,3 +155,4 @@ Config file directives:
   +default_pointer_return_value_policy           pybind11::return_value_policy::reference
   +default_lvalue_reference_return_value_policy  pybind11::return_value_policy::reference_internal
   +default_rvalue_reference_return_value_policy  pybind11::return_value_policy::move
+  +default_call_guard pybind11::gil_scoped_release

--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -144,7 +144,7 @@ Config file directives:
 * ``default_member_rvalue_reference_return_value_policy``, specify return value policy for member functions returning r-value reference. Default
   is 'pybind11::return_value_policy::automatic'.
 
-* ``default_call_guard``, optionally specify a call guard applied to all function definitions. Default None
+* ``default_call_guard``, optionally specify a call guard applied to all function definitions. See `pybind11 documentation <http://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard`_. Default None.
 
 
 

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -66,6 +66,7 @@ void Config::read(string const &file_name)
 	string const _default_member_pointer_return_value_policy_           {"default_member_pointer_return_value_policy"};
 	string const _default_member_lvalue_reference_return_value_policy_	{"default_member_lvalue_reference_return_value_policy"};
 	string const _default_member_rvalue_reference_return_value_policy_  {"default_member_rvalue_reference_return_value_policy"};
+	string const _default_call_guard_   {"default_call_guard"};
 
 	std::ifstream f(file_name);
 	string line;
@@ -134,6 +135,7 @@ void Config::read(string const &file_name)
 					else if( token == _default_member_pointer_return_value_policy_ )          default_member_pointer_return_value_policy_ = name_without_spaces;
 					else if( token == _default_member_lvalue_reference_return_value_policy_ ) default_member_lvalue_reference_return_value_policy_ = name_without_spaces;
 					else if( token == _default_member_rvalue_reference_return_value_policy_ ) default_member_rvalue_reference_return_value_policy_ = name_without_spaces;
+					else if( token == _default_call_guard_ ) default_call_guard_ = name_without_spaces;
 
 					else throw std::runtime_error("Invalid token in config file! Each token must be ether: namespace, class or function! For example: '+function aaa::bb::my_function'. Token: '" + token + "' Line: '" + line + '\'');
 				}

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -40,6 +40,7 @@ private:
 	string default_member_pointer_return_value_policy_          = "pybind11::return_value_policy::automatic";
 	string default_member_lvalue_reference_return_value_policy_ = "pybind11::return_value_policy::automatic";
 	string default_member_rvalue_reference_return_value_policy_ = "pybind11::return_value_policy::automatic";
+	string default_call_guard_ = "";
 
 public:
 	static Config &get();
@@ -64,6 +65,7 @@ public:
 	string const &default_member_pointer_return_value_policy()          { return default_member_pointer_return_value_policy_; }
 	string const &default_member_lvalue_reference_return_value_policy() { return default_member_lvalue_reference_return_value_policy_; }
 	string const &default_member_rvalue_reference_return_value_policy() { return default_member_rvalue_reference_return_value_policy_; }
+	string const &default_call_guard() { return default_call_guard_; }
 
 	string prefix;
 

--- a/source/function.cpp
+++ b/source/function.cpp
@@ -362,6 +362,8 @@ string bind_function(FunctionDecl const *F, uint args_to_bind, bool request_bind
 		if(request_bindings_f) request_bindings( F->getParamDecl(i)->getOriginalType(), context);
 	}
 
+	if(!Config::get().default_call_guard().empty()) r += ", pybind11::call_guard<" + Config::get().default_call_guard() + ">()";
+
 	r += ");";
 
 	return r;

--- a/test/T32.call_guard.config
+++ b/test/T32.call_guard.config
@@ -1,0 +1,1 @@
++default_call_guard pybind11::gil_scoped_release

--- a/test/T32.call_guard.hpp
+++ b/test/T32.call_guard.hpp
@@ -1,0 +1,23 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+//
+// Copyright (c) 2016 University of Washington
+//
+// All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+//
+/// @file   binder/test/T07.class.hpp
+/// @brief  Test gil-release guard configuration.
+/// @author Alex Ford <fordas@uw.edu>
+//
+#ifndef _INCLUDED_T07_class_hpp_
+#define _INCLUDED_T07_class_hpp_
+
+void free(int)   {}
+
+struct Methods
+{
+	void foo(int) {}
+};
+
+#endif

--- a/test/T32.call_guard.ref
+++ b/test/T32.call_guard.ref
@@ -1,0 +1,70 @@
+// File: T32_call_guard.cpp
+#include <T32.call_guard.hpp> // Methods
+#include <T32.call_guard.hpp> // Methods::foo
+#include <T32.call_guard.hpp> // free
+#include <sstream> // __str__
+
+#include <pybind11/pybind11.h>
+
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+	#define BINDER_PYBIND11_TYPE_CASTER
+	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*);
+	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>);
+#endif
+
+void bind_T32_call_guard(std::function< pybind11::module &(std::string const &namespace_) > &M)
+{
+	// free(int) file:T32.call_guard.hpp line:16
+	M("").def("free", (void (*)(int)) &free, "C++: free(int) --> void", pybind11::arg(""), pybind11::call_guard<pybind11::gil_scoped_release>());
+
+	{ // Methods file:T32.call_guard.hpp line:18
+		pybind11::class_<Methods, std::shared_ptr<Methods>> cl(M(""), "Methods", "");
+		pybind11::handle cl_type = cl;
+
+		cl.def( pybind11::init( [](){ return new Methods(); } ) );
+		cl.def("foo", (void (Methods::*)(int)) &Methods::foo, "C++: Methods::foo(int) --> void", pybind11::arg(""), pybind11::call_guard<pybind11::gil_scoped_release>());
+	}
+}
+
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <functional>
+
+#include <pybind11/pybind11.h>
+
+typedef std::function< pybind11::module & (std::string const &) > ModuleGetter;
+
+void bind_T32_call_guard(std::function< pybind11::module &(std::string const &namespace_) > &M);
+
+
+PYBIND11_MODULE(T32_call_guard, root_module) {
+	root_module.doc() = "T32_call_guard module";
+
+	std::map <std::string, pybind11::module> modules;
+	ModuleGetter M = [&](std::string const &namespace_) -> pybind11::module & {
+		auto it = modules.find(namespace_);
+		if( it == modules.end() ) throw std::runtime_error("Attempt to access pybind11::module for namespace " + namespace_ + " before it was created!!!");
+		return it->second;
+	};
+
+	modules[""] = root_module;
+
+	std::vector< std::pair<std::string, std::string> > sub_modules {
+	};
+	for(auto &p : sub_modules ) modules[p.first.size() ? p.first+"::"+p.second : p.second] = modules[p.first].def_submodule(p.second.c_str(), ("Bindings for " + p.first + "::" + p.second + " namespace").c_str() );
+
+	//pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
+
+	bind_T32_call_guard(M);
+
+}
+
+// Source list file: TEST/T32_call_guard.sources
+// T32_call_guard.cpp
+// T32_call_guard.cpp
+
+// Modules list file: TEST/T32_call_guard.modules
+// 

--- a/test/self-test.py
+++ b/test/self-test.py
@@ -95,8 +95,8 @@ def run_test(test_path, build_dir):
     if not_binded: print('{}\n"not_binded" string found in results for test {}!!!\n'.format('\n'.join(not_binded), test)); sys.exit(1)
 
     if r  and  Options.accept:
-            a = input( 'Accept new results from test {} as reference? (yes or no) '.format(test) )
-            if a in ['y', 'yes']: shutil.copyfile(new, ref)
+        a = input( 'Accept new results from test {} as reference? (yes or no) '.format(test) )
+        if a in ['y', 'yes']: shutil.copyfile(new, ref)
 
 
 

--- a/test/self-test.py
+++ b/test/self-test.py
@@ -81,7 +81,7 @@ def run_test(test_path, build_dir):
     command_line = 'cd {build_dir} && clang++ -O3 -shared -std=c++11 -I {pybind11} -I/usr/include/python2.7 -I./.. -I./../.. -I./../../source {root_module}.cpp -o {root_module}.so -fPIC'.format(pybind11=Options.pybind11, root_module=root_module, build_dir=build_dir)
     execute('{} Compiling binding results...'.format(test), command_line);
 
-    command_line = "cd {build_dir} && python -c 'import {root_module}'".format(root_module=root_module, build_dir=build_dir)
+    command_line = "cd {build_dir} && python2.7 -c 'import {root_module}'".format(root_module=root_module, build_dir=build_dir)
     execute('{} Testing imports...'.format(test), command_line);
 
     ref = source_dir + '/' + test_name + '.ref'
@@ -95,8 +95,8 @@ def run_test(test_path, build_dir):
     if not_binded: print('{}\n"not_binded" string found in results for test {}!!!\n'.format('\n'.join(not_binded), test)); sys.exit(1)
 
     if r  and  Options.accept:
-        a = input( 'Accept new results from test {} as reference? (yes or no) '.format(test) )
-        if a in ['y', 'yes']: shutil.copyfile(new, ref)
+            a = input( 'Accept new results from test {} as reference? (yes or no) '.format(test) )
+            if a in ['y', 'yes']: shutil.copyfile(new, ref)
 
 
 


### PR DESCRIPTION
Adds additional binder configuration parameter allowing optional
specification of a default call guard. This call guard is applied to
all generated function invocations. Intended to support project-wide
application of gil_scoped_release in code bases in which all c++ code is
(a) gil-safe or (b) protects all python api access via gil state ensure.

Includes documentation, test, and configuration updates. Includes minor
update to test script to explictly specify python2.7 for test execution,
providing support for environments in which python is mapped to python3.