### PR TITLE
Example cmake script

### DIFF
--- a/examples/example_struct/config.cfg
+++ b/examples/example_struct/config.cfg
@@ -1,0 +1,1 @@
++include <pybind11/stl.h>

--- a/examples/example_struct/make_bindings_via_cmake.py
+++ b/examples/example_struct/make_bindings_via_cmake.py
@@ -8,83 +8,97 @@ import subprocess
 from distutils.sysconfig import get_python_inc
 
 
-binder_executable = glob.glob(f"{os.getcwd()}/../../build/llvm-4.0.0/build_4.0.0*/bin/binder")[0]
-project_source = "include"
+# Overall script settings
+binder_executable = glob.glob(f'{os.getcwd()}/../../build/llvm-4.0.0/build_4.0.0*/bin/binder')[0]
+bindings_dir = 'cmake_bindings'
+binder_source = f'{os.getcwd()}/../../source'
+pybind_source = f'{os.getcwd()}/../../build/pybind11/include'
+use_pybind_stl = True
+#use_pybind_stl = False
+this_project_source = f'{os.getcwd()}/include'
+this_project_include = this_project_source
+this_project_namespace_to_bind = 'testers'
+python_module_name = 'test_struct'
 
 def make_all_includes():
     all_includes = []
-    all_include_filename = "all_cmake_includes.hpp"
-    for filename in (glob.glob(f"{project_source}/**/*.hpp", recursive=True)+
-                     glob.glob(f"{project_source}/**/*.cpp", recursive=True)+
-                     glob.glob(f"{project_source}/**/*.h", recursive=True)+
-                     glob.glob(f"{project_source}/**/*.cc", recursive=True)
-    ):
+    all_include_filename = 'all_cmake_includes.hpp'
+    for filename in (glob.glob(f'{this_project_source}/**/*.hpp', recursive=True)+
+                     glob.glob(f'{this_project_source}/**/*.cpp', recursive=True)+
+                     glob.glob(f'{this_project_source}/**/*.h', recursive=True)+
+                     glob.glob(f'{this_project_source}/**/*.cc', recursive=True)+
+                     glob.glob(f'{this_project_source}/**/*.c', recursive=True)):
         with open(filename, 'r') as fh:
             for line in fh:
-                if line.startswith("#include"):
+                if line.startswith('#include'):
                     all_includes.append(line.strip())
     all_includes = list(set(all_includes))
     with open(all_include_filename, 'w') as fh:
         for include in all_includes:
-            fh.write(f"{include}\n")
+            fh.write(f'{include}\n')
     return all_include_filename
 
 
 def make_bindings_code(all_includes_fn):
-    bindings_dir = "cmake_bindings"
     shutil.rmtree(bindings_dir, ignore_errors=True)
     os.mkdir(bindings_dir)
-    command = f'{binder_executable} --root-module test_struct --prefix {os.getcwd()}/{bindings_dir}/ --bind testers -trace {all_includes_fn}  -- -std=c++11 -I{os.getcwd()}/include -DNDEBUG -v'.split()
-    print(" ".join(command))
+    command = (f'{binder_executable} --root-module {python_module_name} '
+               f'--prefix {os.getcwd()}/{bindings_dir}/ '
+               f'--bind {this_project_namespace_to_bind} '
+               + ('--config config.cfg ' if use_pybind_stl else '') +
+               f'-trace {all_includes_fn}  -- -std=c++11 '
+               f'-I{this_project_include} -DNDEBUG -v').split()
+    print(' '.join(command))
     ret = subprocess.call(command)
     sources_to_compile = []
-    with open(f"{bindings_dir}/test_struct.sources", 'r') as fh:
+    with open(f'{bindings_dir}/{python_module_name}.sources', 'r') as fh:
         for line in fh:
             sources_to_compile.append(line.strip())
     return sources_to_compile
 
 
 def compile_sources(sources_to_compile):
-    bindings_dir = "cmake_bindings"
     og_dir = os.getcwd()
     os.chdir(bindings_dir)
     lines_to_write = []
-    lines_to_write.append("project(test_struct)")
+    lines_to_write.append(f'project({python_module_name})')
 
-    binder_source = f"{os.getcwd()}/../../../source"
-    this_project_source = f"{os.getcwd()}/../include"
-    pybind_source = f"{os.getcwd()}/../../../build/pybind11/include"
     compiled_sources = []
     include_directories = []
-    for include_dir in [binder_source, this_project_source, pybind_source, get_python_inc()]:
-        lines_to_write.append(f"include_directories({include_dir})")
-    lines_to_write.append("set_property(GLOBAL PROPERTY POSITION_INDEPENDENT_CODE ON)")
-    lines_to_write.append("add_definitions(-DNDEBUG)")
+    for include_dir in [binder_source, this_project_source, this_project_include, pybind_source, get_python_inc()]:
+        lines_to_write.append(f'include_directories({include_dir})')
+    lines_to_write.append('set_property(GLOBAL PROPERTY POSITION_INDEPENDENT_CODE ON)') # -fPIC
+    lines_to_write.append('add_definitions(-DNDEBUG)')
 
-    lines_to_write.append("add_library(test_struct SHARED")
+    lines_to_write.append(f'add_library({python_module_name} SHARED')
     for source in sources_to_compile:
-        lines_to_write.append(f"\t{source}")
-    lines_to_write.append(")")
-    lines_to_write.append('set_target_properties(test_struct PROPERTIES PREFIX "")')
-    lines_to_write.append("set_target_properties(test_struct PROPERTIES SUFFIX \".so\")")
+        lines_to_write.append(f'\t{source}')
+    lines_to_write.append(')')
+    lines_to_write.append(f'set_target_properties({python_module_name} PROPERTIES PREFIX "")')
+    lines_to_write.append(f'set_target_properties({python_module_name} PROPERTIES SUFFIX ".so")')
 
-    with open("CMakeLists.txt", 'w') as f:
+    with open('CMakeLists.txt', 'w') as f:
         for line in lines_to_write:
-            f.write(f"{line}\n")
+            f.write(f'{line}\n')
     # Done making CMakeLists.txt
-    subprocess.call("cmake -G Ninja".split())
-    subprocess.call("ninja")
+    subprocess.call('cmake -G Ninja'.split())
+    subprocess.call('ninja')
     sys.path.append('.')
-    import test_struct
-    test_obj = test_struct.testers.test_my_struct()
-    print(test_obj.an_int)
+    if python_module_name == 'test_struct':
+        sys.stdout.flush()
+        print('Testing Python lib...')
+        import test_struct
+        test_obj = test_struct.testers.test_my_struct()
+        print(test_obj.an_int)
+        if use_pybind_stl:
+            print(test_obj.a_vector)
 
 
 def main():
-   all_includes_fn =  make_all_includes()
-   sources_to_compile = make_bindings_code(all_includes_fn)
-   compile_sources(sources_to_compile)
+    all_includes_fn =  make_all_includes()
+    sources_to_compile = make_bindings_code(all_includes_fn)
+    compile_sources(sources_to_compile)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/examples/example_struct/make_bindings_via_cmake.py
+++ b/examples/example_struct/make_bindings_via_cmake.py
@@ -8,10 +8,17 @@ import subprocess
 from distutils.sysconfig import get_python_inc
 
 
+binder_executable = glob.glob(f"{os.getcwd()}/../../build/llvm-4.0.0/build_4.0.0*/bin/binder")[0]
+project_source = "include"
+
 def make_all_includes():
     all_includes = []
     all_include_filename = "all_cmake_includes.hpp"
-    for filename in glob.glob("include/**/*.hpp", recursive=True):
+    for filename in (glob.glob(f"{project_source}/**/*.hpp", recursive=True)+
+                     glob.glob(f"{project_source}/**/*.cpp", recursive=True)+
+                     glob.glob(f"{project_source}/**/*.h", recursive=True)+
+                     glob.glob(f"{project_source}/**/*.cc", recursive=True)
+    ):
         with open(filename, 'r') as fh:
             for line in fh:
                 if line.startswith("#include"):
@@ -27,7 +34,6 @@ def make_bindings_code(all_includes_fn):
     bindings_dir = "cmake_bindings"
     shutil.rmtree(bindings_dir, ignore_errors=True)
     os.mkdir(bindings_dir)
-    binder_executable = glob.glob(f"{os.getcwd()}/../../build/llvm-4.0.0/build_4.0.0*/bin/binder")[0]
     command = f'{binder_executable} --root-module test_struct --prefix {os.getcwd()}/{bindings_dir}/ --bind testers -trace {all_includes_fn}  -- -std=c++11 -I{os.getcwd()}/include -DNDEBUG -v'.split()
     print(" ".join(command))
     ret = subprocess.call(command)


### PR DESCRIPTION
1) Make it easier to use cmake example script with other projects. All paths and settings are in the single place (in the top of the script)
2) Unify usage of quotes (to visually stress the difference from C\C++ I selected single quotes, however, it is not a problem to put all of them to be double quotes).  
3) Add other often used file extensions widely used in C++ projects.
4) In many projects they use separate include and source dir. I am not sure whether line "for include_dir in [binder_source, .." is OK now for Binder, as it includes both this_project_source and this_project_include (which are the same for example_structure project).
5) Added missing config file which is also needed for make_binding_via_bash_and_stl.sh