### PR TITLE
Few tweaks to support building with MSVC

### DIFF
--- a/source/config.hpp
+++ b/source/config.hpp
@@ -18,6 +18,11 @@
 #include <vector>
 #include <map>
 
+#ifdef _MSC_VER
+#include <ciso646>
+using uint = unsigned int;
+#endif
+
 namespace binder {
 
 class Config


### PR DESCRIPTION
Binder can be built with MSVC (I used VS 2017) with only a few minor tweaks. They are:

- Alias `uint` to `unsigned int`
  - I'm not sure how in the include chain `uint` gets defined on Linux or Clang/gcc, but for MSVC it's undefined
- Include `<ciso646>`
  - MSVC by default does not support the alternative operator representations (e.g. `or`, `and`). However, they can be added in by including `<ciso646>`