### PR TITLE
Support Clang 7

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -3,6 +3,7 @@
 #set(CMAKE_CXX_FLAGS "-fexceptions ${CMAKE_CXX_FLAGS}")
 
 set(LLVM_LINK_COMPONENTS support)
+set(LLVM_USED_LIBS clangTooling clangBasic clangAST)
 
 add_clang_executable(binder
   binder.cpp
@@ -33,9 +34,17 @@ add_clang_executable(binder
   fmt/posix.cc
   )
 
-target_link_libraries(binder
-  PRIVATE
-  clangTooling
-  clangBasic
-  clangASTMatchers
-  )
+if(LLVM_VERSION_MAJOR GREATER 5)
+  target_link_libraries(binder
+    PRIVATE
+    clangTooling
+    clangBasic
+    clangASTMatchers
+    )
+else()
+  target_link_libraries(binder
+    clangTooling
+    clangBasic
+    clangASTMatchers
+    )
+endif()

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -3,7 +3,6 @@
 #set(CMAKE_CXX_FLAGS "-fexceptions ${CMAKE_CXX_FLAGS}")
 
 set(LLVM_LINK_COMPONENTS support)
-set(LLVM_USED_LIBS clangTooling clangBasic clangAST)
 
 add_clang_executable(binder
   binder.cpp
@@ -35,6 +34,7 @@ add_clang_executable(binder
   )
 
 target_link_libraries(binder
+  PRIVATE
   clangTooling
   clangBasic
   clangASTMatchers

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -35,7 +35,6 @@ using std::unordered_map;
 using std::make_pair;
 
 using namespace fmt::literals;
-using fmt::format;
 
 namespace binder {
 
@@ -422,7 +421,7 @@ void Context::generate(Config const &config)
 			}
 			if( i < binders.size() ) --i;
 
-			code = generate_include_directives(includes) + format(module_header, config.includes_code()) + prefix_code + "void " + function_name + module_function_suffix + "\n{\n" + code + "}\n";
+			code = generate_include_directives(includes) + fmt::format(module_header, config.includes_code()) + prefix_code + "void " + function_name + module_function_suffix + "\n{\n" + code + "}\n";
 
 			if( O_single_file ) root_module_file_handle << "// File: " << file_name << '\n' << code << "\n\n";
 			else update_source_file(config.prefix, file_name, code);
@@ -446,7 +445,7 @@ void Context::generate(Config const &config)
 	}
 
 	std::stringstream s;
-	s << format(main_module_header, binding_function_decls, config.root_module, namespace_pairs, binding_function_calls);
+	s << fmt::format(main_module_header, binding_function_decls, config.root_module, namespace_pairs, binding_function_calls);
 
 	root_module_file_handle << s.str();
 

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -40,7 +40,7 @@ namespace binder {
 /// check if user requested binding for the given QualType
 bool is_binding_requested(clang::QualType const &qt, Config const &config)
 {
-	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) return is_binding_requested(pt->getPointeeType(), config);
+	if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) return is_binding_requested(pt->getPointeeType(), config);
 
 	if( ReferenceType const *rt = dyn_cast<ReferenceType>( qt.getTypePtr() ) ) return is_binding_requested(rt->getPointeeType(), config);
 
@@ -53,7 +53,7 @@ bool is_binding_requested(clang::QualType const &qt, Config const &config)
 // check if user requested skipping for the given declaration
 bool is_skipping_requested(QualType const &qt, Config const &config)
 {
-	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) return is_skipping_requested(pt->getPointeeType(), config);
+	if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) return is_skipping_requested(pt->getPointeeType(), config);
 
 	if( ReferenceType const *rt = dyn_cast<ReferenceType>( qt.getTypePtr() ) ) return is_skipping_requested(rt->getPointeeType(), config);
 
@@ -305,7 +305,7 @@ void add_relevant_includes(QualType const &qt, /*const ASTContext &context,*/ In
 {
 	//QualType qt = qt.getDesugaredType(context);
 	//outs() << "add_relevant_includes(qt): " << qt.getAsString() << "\n";
-	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) add_relevant_includes(pt->getPointeeType(), includes, level);
+	if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) add_relevant_includes(pt->getPointeeType(), includes, level);
 	if( ReferenceType const *rt = dyn_cast<ReferenceType>( qt.getTypePtr() ) ) add_relevant_includes(rt->getPointeeType(), includes, level);
 	if( CXXRecordDecl *r = qt->getAsCXXRecordDecl() ) add_relevant_includes(r, includes, level);
 	if( EnumDecl *e = dyn_cast_or_null<EnumDecl>( qt->getAsTagDecl() ) ) add_relevant_includes(e, includes, level);
@@ -319,7 +319,7 @@ bool is_bindable(QualType const &qt)
 
 	r &= !qt->isFunctionPointerType()  and  !qt->isRValueReferenceType()  and  !qt->isInstantiationDependentType()  and  !qt->isArrayType();  //and  !qt->isConstantArrayType()  and  !qt->isIncompleteArrayType()  and  !qt->isVariableArrayType()  and  !qt->isDependentSizedArrayType()
 
-	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) {
+	if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) {
 		QualType pqt = pt->getPointeeType();
 
 		if( pqt->isPointerType() ) return false;  // refuse to bind 'value**...' types
@@ -347,7 +347,7 @@ bool is_bindable(QualType const &qt)
 		r &= is_bindable( pqt/*.getCanonicalType()*/ );
 	}
 
-	if( Type const *tp = qt/*.getCanonicalType()*/.getTypePtrOrNull() ) {
+	if( clang::Type const *tp = qt/*.getCanonicalType()*/.getTypePtrOrNull() ) {
 		if( CXXRecordDecl *rd = tp->getAsCXXRecordDecl() ) {
 			//outs() << "is_bindable qt CXXRecordDecl:" << rd->getQualifiedNameAsString() << " " << is_bindable(rd) << "\n";
 			r &= is_bindable(rd);
@@ -371,7 +371,7 @@ void request_bindings(clang::QualType const &qt, Context &context)
 			if( td->isCompleteDefinition()  or  dyn_cast<ClassTemplateSpecializationDecl>(td) ) context.request_bindings( typename_from_type_decl(td) );
 		}
 
-		if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) {
+		if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) {
 			request_bindings( pt->getPointeeType()/*.getCanonicalType()*/, context );
 		}
 


### PR DESCRIPTION
I'm prototyping using binder with Visual Studio 2017, which means that it needs to parse the MSVC STL. This *mostly* works, but not completely. For VS 2017, Clang needs the `-fms-compatibility-version=20` flag, which is only supported in Clang 7 (Clang 4 only has up to `-fms-compatibility-version=19`). Turns out there aren't too many changes needed to make binder build with LLVM/Clang 7! They are:

- Remove `using fmt::format` and change calls to `format` to `fmt::format`
  - At some point Clang introduced their own `format` function, which conflicts with the one binder builds in. Using the namespaced version resolves to the correct function
- Disambiguate between `llvm::PointeeType`, `clang::PointeeType`, `llvm::Type`, and `clang::Type`
  - Along the some vein, LLVM added in a `PointeeType` and `Type`; and since we're `using namespace llvm` and `using namespace clang` in `type.cpp`, there's a conflict
- Update `CMakeLists.txt` to use private target libraries for Clang 6+
  - The Clang build system was updated with Clang 6, and targets need to mark their libraries as private. It's a little ugly, but marking the libraries as private in <= 5 actually fails, so I had to switch based on `LLVM_VERSION_MAJOR`