### PR TITLE
Fix Windows line endings in config file on Linux

### DIFF
--- a/source/config.cpp
+++ b/source/config.cpp
@@ -75,6 +75,11 @@ void Config::read(string const &file_name)
 		if( line.size() ) {
 			if( line[0] == '#' ) continue;
 
+			if( line.back() == '\r' ) {
+				line.pop_back();
+				if( line.empty() ) continue;
+			}
+
 			if( line[0] == '+'  or  line[0] == '-' ) {
 				size_t space = line.find(' ');
 				if(  space == string::npos ) throw std::runtime_error("Invalid line in config file! Each line must have token separated with space from object name. For example: '+function aaa::bb::my_function'. Line: " + line);


### PR DESCRIPTION
If the config file has Windows-style line endings (`\r\n`) and is read on Linux, things get a bit funky. This is because `std::getline` returns lines with a carriage return at the end when it encounters Windows-style endings on Linux (it treats the `\r` as any old character and adds it to the returned line).

An example of what's broke: directives to skip classes don't work because all the members of `Config::classes_to_skip` have a `\r` at the end, causing the lookup to always fail.

The simple, if inelegant, fix is to simply check to see if the last character of the result from `std::getline` is a carriage return, and if so pop it off.

