### PR TITLE
a way to suppress errors if the not-found included headers

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -31,6 +31,9 @@ files. Typically the following files will be generated: ``<root-module>.cpp``, `
 `--single-file` if specified instruct Binder to put generated sources into single large file. This might be useful for small projects.
 
 
+`--suppress-errors=true` if the generated bindings codes are correct but there are some fatal errors from clang and you want to get rid of them. This situation can happen when you would like to generate binding codes for a small part of a huge project and the you cannot include all the required header files with `-I` to the command.
+
+
 `--annotate-includes` [debug] if specified Binder will comment each include with type name which trigger it inclusion.
 
 

--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -31,7 +31,7 @@ files. Typically the following files will be generated: ``<root-module>.cpp``, `
 `--single-file` if specified instruct Binder to put generated sources into single large file. This might be useful for small projects.
 
 
-`--suppress-errors=true` if the generated bindings codes are correct but there are some fatal errors from clang and you want to get rid of them. This situation can happen when you would like to generate binding codes for a small part of a huge project and the you cannot include all the required header files with `-I` to the command.
+`--suppress-errors` if the generated bindings codes are correct but there are some fatal errors from clang and you want to get rid of them. This situation can happen when you would like to generate binding codes for a small part of a huge project and the you cannot include all the required header files with `-I` to the command.
 
 
 `--annotate-includes` [debug] if specified Binder will comment each include with type name which trigger it inclusion.

--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -31,6 +31,8 @@
 #include <class.hpp>
 #include <util.hpp>
 
+#include <clang/Basic/Diagnostic.h>
+
 
 using namespace clang::tooling;
 using namespace llvm;
@@ -75,6 +77,8 @@ cl::opt<bool> O_trace("trace", cl::desc("Add tracer output for each binded objec
 
 cl::opt<bool> O_verbose("v", cl::desc("Increase verbosity of output"), cl::init(false), cl::cat(BinderToolCategory));
 
+cl::opt<bool> O_suppress_errors("suppress-errors", cl::desc("Suppres all the compilers errors when you are sure about your code and the errors are in private parts of your class."), cl::init(false), cl::cat(BinderToolCategory));
+
 
 class ClassVisitor : public RecursiveASTVisitor<ClassVisitor>
 {
@@ -117,6 +121,11 @@ public:
 		config.namespaces_to_skip = O_skip;
 
 		if( O_config.size() ) config.read(O_config);
+		if(O_suppress_errors)
+		{
+			clang::DiagnosticsEngine& di = ci->getDiagnostics();
+			di.setSuppressAllDiagnostics();
+		}
 	}
 
 	virtual ~BinderVisitor() {}
@@ -239,7 +248,6 @@ int main(int argc, const char **argv)
 	CommonOptionsParser op(argc, argv, BinderToolCategory);
 
 	ClangTool tool(op.getCompilations(), op.getSourcePathList());
-
 	//outs() << "Root module: " << O_root_module << "\n";
 	//for(auto &s : O_bind) outs() << "Binding: '" << s << "'\n";
 

--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -77,7 +77,7 @@ cl::opt<bool> O_trace("trace", cl::desc("Add tracer output for each binded objec
 
 cl::opt<bool> O_verbose("v", cl::desc("Increase verbosity of output"), cl::init(false), cl::cat(BinderToolCategory));
 
-cl::opt<bool> O_suppress_errors("suppress-errors", cl::desc("Suppres all the compilers errors when you are sure about your code and the errors are in private parts of your class."), cl::init(false), cl::cat(BinderToolCategory));
+cl::opt<bool> O_suppress_errors("suppress-errors", cl::desc("Suppres all the compilers errors. This option could be useful when you want to tell Binder to ignore non-critical errors (for example due to missing includes) and generate binding for part of code that Binder was able to parse"), cl::init(false), cl::cat(BinderToolCategory));
 
 
 class ClassVisitor : public RecursiveASTVisitor<ClassVisitor>

--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -121,8 +121,7 @@ public:
 		config.namespaces_to_skip = O_skip;
 
 		if( O_config.size() ) config.read(O_config);
-		if(O_suppress_errors)
-		{
+		if( O_suppress_errors )	{
 			clang::DiagnosticsEngine& di = ci->getDiagnostics();
 			di.setSuppressAllDiagnostics();
 		}

--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -21,18 +21,15 @@
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/AST/Comment.h>
+#include <clang/Basic/Diagnostic.h>
 
-// Declares llvm::cl::extrahelp.
-#include "llvm/Support/CommandLine.h"
+#include <llvm/Support/CommandLine.h> // Declares llvm::cl::extrahelp
 
 #include <context.hpp>
 #include <enum.hpp>
 #include <function.hpp>
 #include <class.hpp>
 #include <util.hpp>
-
-#include <clang/Basic/Diagnostic.h>
-
 
 using namespace clang::tooling;
 using namespace llvm;


### PR DESCRIPTION
are not useful in generating bindings and you are sure that
the bindings are still correct and you want to suppress ugly
fatal errors then you can use --suppress-errors=true as argument
to get rid of them.

Sorry. This is the same as https://github.com/RosettaCommons/binder/pull/65
I had to rebranch stuff on my repo. So it closed the other PR.