### PR TITLE
Use variable names as well for overloaded constructors

### DIFF
--- a/source/class.cpp
+++ b/source/class.cpp
@@ -882,6 +882,7 @@ struct ConstructorBindingInfo
 //char const * constructor_if_template = "\tcl.def(\"__init__\", [cl_type](pybind11::handle self_{0}) {{ if (self_.get_type() == cl_type) new (self_.cast<{2} *>()) {2}({1}); else new (self_.cast<{3} *>()) {3}({1}); }}, \"doc\");";
 
 char const * constructor_template =                 "\tcl.def( pybind11::init( []({0}){{ return new {2}({1}); }} ), \"doc\");";
+char const * constructor_template_with_pyArg =      "\tcl.def( pybind11::init( []({0}){{ return new {2}({1}); }} ), \"doc\" {3});";
 char const * constructor_with_trampoline_template = "\tcl.def( pybind11::init( []({0}){{ return new {2}({1}); }}, []({0}){{ return new {3}({1}); }} ), \"doc\");";
 //char const * constructor_lambda_template = "\tcl.def(pybind11::init( []({0}){{ return new {2}({1}); }}, []({0}){{ return new {3}({1}); }} ), \"doc\");";
 
@@ -910,6 +911,11 @@ string bind_constructor(ConstructorBindingInfo const &CBI, uint args_to_bind, bo
 
 		//string params = args_to_bind ? ", " + args.first : "";
 		string params = args_to_bind ? args.first : "";
+		
+		string argsHelper;
+		for(uint i=0; i<CBI.T->getNumParams()  and  i < args_to_bind; ++i) {
+			argsHelper += ", pybind11::arg(\"{}\")"_format( string( CBI.T->getParamDecl(i)->getName() ) );
+		}
 
 		// if( CBI.T->isVariadic() ) c = fmt::format(constructor_lambda_template, params, args.second, constructor_types.first, constructor_types.second);
 		// else if( constructor_types.first.size()  and  constructor_types.second.size() ) c = fmt::format(constructor_lambda_template, params, args.second, constructor_types.first, constructor_types.second);
@@ -918,6 +924,7 @@ string bind_constructor(ConstructorBindingInfo const &CBI, uint args_to_bind, bo
 
 		if( CBI.C->isAbstract() ) c = fmt::format(constructor_template, params, args.second, CBI.trampoline_qualified_name);
 		else if( CBI.trampoline ) c = fmt::format(constructor_with_trampoline_template, params, args.second, CBI.class_qualified_name, CBI.trampoline_qualified_name);
+		else if( args_to_bind )c = fmt::format(constructor_template_with_pyArg, params, args.second, CBI.class_qualified_name, argsHelper);
 		else c = fmt::format(constructor_template, params, args.second, CBI.class_qualified_name);
 	}
 

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -882,7 +882,7 @@ struct ConstructorBindingInfo
 //char const * constructor_if_template = "\tcl.def(\"__init__\", [cl_type](pybind11::handle self_{0}) {{ if (self_.get_type() == cl_type) new (self_.cast<{2} *>()) {2}({1}); else new (self_.cast<{3} *>()) {3}({1}); }}, \"doc\");";
 
 char const * constructor_template =                 "\tcl.def( pybind11::init( []({0}){{ return new {2}({1}); }} ), \"doc\");";
-char const * constructor_template_with_pyArg =      "\tcl.def( pybind11::init( []({0}){{ return new {2}({1}); }} ), \"doc\" {3});";
+char const * constructor_template_with_py_arg =      "\tcl.def( pybind11::init( []({0}){{ return new {2}({1}); }} ), \"doc\" {3});";
 char const * constructor_with_trampoline_template = "\tcl.def( pybind11::init( []({0}){{ return new {2}({1}); }}, []({0}){{ return new {3}({1}); }} ), \"doc\");";
 //char const * constructor_lambda_template = "\tcl.def(pybind11::init( []({0}){{ return new {2}({1}); }}, []({0}){{ return new {3}({1}); }} ), \"doc\");";
 
@@ -913,6 +913,7 @@ string bind_constructor(ConstructorBindingInfo const &CBI, uint args_to_bind, bo
 		string params = args_to_bind ? args.first : "";
 		
 		string argsHelper;
+		
 		for(uint i=0; i<CBI.T->getNumParams()  and  i < args_to_bind; ++i) {
 			argsHelper += ", pybind11::arg(\"{}\")"_format( string( CBI.T->getParamDecl(i)->getName() ) );
 		}
@@ -924,8 +925,7 @@ string bind_constructor(ConstructorBindingInfo const &CBI, uint args_to_bind, bo
 
 		if( CBI.C->isAbstract() ) c = fmt::format(constructor_template, params, args.second, CBI.trampoline_qualified_name);
 		else if( CBI.trampoline ) c = fmt::format(constructor_with_trampoline_template, params, args.second, CBI.class_qualified_name, CBI.trampoline_qualified_name);
-		else if( args_to_bind )c = fmt::format(constructor_template_with_pyArg, params, args.second, CBI.class_qualified_name, argsHelper);
-		else c = fmt::format(constructor_template, params, args.second, CBI.class_qualified_name);
+		else c = fmt::format(constructor_template_with_py_arg, params, args.second, CBI.class_qualified_name, argsHelper);
 	}
 
 	return c;

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -912,10 +912,10 @@ string bind_constructor(ConstructorBindingInfo const &CBI, uint args_to_bind, bo
 		//string params = args_to_bind ? ", " + args.first : "";
 		string params = args_to_bind ? args.first : "";
 		
-		string argsHelper;
+		string args_helper;
 		
 		for(uint i=0; i<CBI.T->getNumParams()  and  i < args_to_bind; ++i) {
-			argsHelper += ", pybind11::arg(\"{}\")"_format( string( CBI.T->getParamDecl(i)->getName() ) );
+			args_helper += ", pybind11::arg(\"{}\")"_format( string( CBI.T->getParamDecl(i)->getName() ) );
 		}
 
 		// if( CBI.T->isVariadic() ) c = fmt::format(constructor_lambda_template, params, args.second, constructor_types.first, constructor_types.second);
@@ -925,7 +925,7 @@ string bind_constructor(ConstructorBindingInfo const &CBI, uint args_to_bind, bo
 
 		if( CBI.C->isAbstract() ) c = fmt::format(constructor_template, params, args.second, CBI.trampoline_qualified_name);
 		else if( CBI.trampoline ) c = fmt::format(constructor_with_trampoline_template, params, args.second, CBI.class_qualified_name, CBI.trampoline_qualified_name);
-		else c = fmt::format(constructor_template_with_py_arg, params, args.second, CBI.class_qualified_name, argsHelper);
+		else c = fmt::format(constructor_template_with_py_arg, params, args.second, CBI.class_qualified_name, args_helper);
 	}
 
 	return c;

--- a/source/function.cpp
+++ b/source/function.cpp
@@ -86,8 +86,8 @@ pair<string, string> function_arguments_for_lambda(clang::FunctionDecl const *re
 		QualType qt = record->getParamDecl(i)->getOriginalType().getCanonicalType();
 		r += qt.getAsString() + ' ';
 		if( !qt->isReferenceType()  and  !qt->isPointerType() ) r += !qt.isConstQualified() ? "const & " : "& ";
-		r += "a" + std::to_string(i);
-		a += "a" + std::to_string(i);
+		r += string( record->getParamDecl(i)->getName() );
+		a += string( record->getParamDecl(i)->getName() );
 		if( i+1 != record->getNumParams()  and  i+1 != n ) { r += ", ";  a += ", "; }
 	}
 

--- a/source/function.cpp
+++ b/source/function.cpp
@@ -86,8 +86,8 @@ pair<string, string> function_arguments_for_lambda(clang::FunctionDecl const *re
 		QualType qt = record->getParamDecl(i)->getOriginalType().getCanonicalType();
 		r += qt.getAsString() + ' ';
 		if( !qt->isReferenceType()  and  !qt->isPointerType() ) r += !qt.isConstQualified() ? "const & " : "& ";
-		r += string( record->getParamDecl(i)->getName() );
-		a += string( record->getParamDecl(i)->getName() );
+		r += "a" + std::to_string(i);
+		a += "a" + std::to_string(i);
 		if( i+1 != record->getNumParams()  and  i+1 != n ) { r += ", ";  a += ", "; }
 	}
 


### PR DESCRIPTION
Use variable names for overloaded constructors instead of a1, a2 ...
And more importantly add `pybind11::arg` to get proper helpers inside the python for overloaded constructors with arguments with default values.