### PR TITLE
Fix binder_for_namespace docs

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -144,7 +144,7 @@ Config file directives:
 
 .. code-block:: bash
 
-  +add_on_binder_for_namespace aaaa add_on_binder_for_namespace_aaaa
+  +binder_for_namespace aaaa binder_for_namespace_aaaa
 
 
 


### PR DESCRIPTION
Fixes the config example to refer to `binder_for_namespace` instead of `add_on_binder_for_namespace`.