### PR TITLE
Very tiny fixes

### DIFF
--- a/documentation/install.rst
+++ b/documentation/install.rst
@@ -82,7 +82,7 @@ Some examples are described in detail below.
 
  Then the compilation can be performed using the following shell
 
- ``scl enable llvm-toolset-7 bash``
+ ``scl enable llvm-toolset-7.0 bash``
 
 
 - For the Fedora 31+ the dependencies can be installed from the standard repositories. Run as root 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -35,6 +35,7 @@ add_clang_executable(binder
   )
 
 target_link_libraries(binder
+  PRIVATE
   clangTooling
   clangBasic
   clangASTMatchers


### PR DESCRIPTION
Added PRIVATE keyword to libraries to remove error/warning 'all-keyword or all-plain' and fixed typo in docs.