### PR TITLE
Implement option for output in multiple files with fixed name.

### DIFF
--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -70,7 +70,7 @@ cl::opt<bool> O_annotate_includes("annotate-includes", cl::desc("Annotate each i
 
 cl::opt<bool> O_single_file("single-file", cl::desc("Concatenate all binder output into single file with name: root-module-name + '.cpp'. Use this for a small projects and for testing."), cl::init(false), cl::cat(BinderToolCategory));
 
-cl::opt<int> O_single_file("multiple-files", cl::desc("Similar to the single-file option, but the output is split into n pieces and written into files with names: root-module-name + 'k.cpp', k=1..n."), cl::init(0), cl::cat(BinderToolCategory));
+cl::opt<int> O_multiple_files("multiple-files", cl::desc("Similar to the single-file option, but the output is split into n pieces if possible and is  written to files with names: root-module-name + '_k.cpp', k=1..n."), cl::init(0), cl::cat(BinderToolCategory));
 
 cl::opt<bool> O_trace("trace", cl::desc("Add tracer output for each binded object (i.e. for debugging)"), cl::init(false), cl::cat(BinderToolCategory));
 

--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -70,6 +70,8 @@ cl::opt<bool> O_annotate_includes("annotate-includes", cl::desc("Annotate each i
 
 cl::opt<bool> O_single_file("single-file", cl::desc("Concatenate all binder output into single file with name: root-module-name + '.cpp'. Use this for a small projects and for testing."), cl::init(false), cl::cat(BinderToolCategory));
 
+cl::opt<int> O_single_file("multiple-files", cl::desc("Similar to the single-file option, but the output is split into n pieces and written into files with names: root-module-name + 'k.cpp', k=1..n."), cl::init(0), cl::cat(BinderToolCategory));
+
 cl::opt<bool> O_trace("trace", cl::desc("Add tracer output for each binded object (i.e. for debugging)"), cl::init(false), cl::cat(BinderToolCategory));
 
 cl::opt<bool> O_verbose("v", cl::desc("Increase verbosity of output"), cl::init(false), cl::cat(BinderToolCategory));

--- a/source/binder.hpp
+++ b/source/binder.hpp
@@ -19,6 +19,7 @@
 
 extern llvm::cl::opt<bool> O_annotate_includes;
 extern llvm::cl::opt<bool> O_single_file;
+extern llvm::cl::opt<int>  O_multiple_files;
 extern llvm::cl::opt<bool> O_trace;
 extern llvm::cl::opt<bool> O_verbose;
 

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -458,9 +458,9 @@ void Context::generate(Config const &config)
 
 			code = generate_include_directives(includes) + fmt::format(module_header, config.includes_code()) + prefix_code + "void " + function_name + module_function_suffix + "\n{\n" + code + "}\n";
 
-                        if( O_multiple_files>0 ) {
-                        outputs.push_back(std::pair<string,string>(file_name,code));
-			else {
+			if( O_multiple_files>0 ) {
+			outputs.push_back(std::pair<string,string>(file_name,code));                        
+			} else {
 			if( O_single_file ) root_module_file_handle << "// File: " << file_name << '\n' << code << "\n\n";
 			else update_source_file(config.prefix, file_name, code);
                         }
@@ -501,23 +501,26 @@ void Context::generate(Config const &config)
 		}
 		int remlines=tot;
 		int j=0;
-		for (int i=0;i<O_single_file;i++)
+		for (int i=0;i<O_multiple_files;i++)
 		{
-		int maxput=remlines/(O_single_file-i);
-		std::ofstream t(config.prefix +config.root_module + "_"+std::to_string(i)+".cpp");
+		int written=0;
+		int maxput=remlines/(O_multiple_files-i);
+		std::ofstream t(config.prefix +config.root_module + "_"+std::to_string(i+1)+".cpp");
 		while (remlines>0&&maxput>0)
 		{
+		if (maxput*2<outputs_size.at(j)&&i!=O_multiple_files-1&&written>0) break; //This is actually an optimization.
 		t<<"// File: " << outputs.at(j).first << '\n';
 		t<<outputs.at(j).second<< '\n';
 		remlines-=outputs_size.at(j);
 		maxput-=outputs_size.at(j);
+		written+=outputs_size.at(j);
 		j++;
 		}
 		t.close();
 		}
 	
 		std::ofstream f(config.prefix + config.root_module + ".sources");
-		for (int i=0;i<O_single_file;i++) f << config.root_module + "_"+std::to_string(i)+".cpp" << "\n";
+		for (int i=0;i<O_multiple_files;i++) f << config.root_module + "_"+std::to_string(i+1)+".cpp" << "\n";
 
 		std::ofstream namespaces_file_handle(config.prefix + config.root_module + ".modules");
 		namespaces_file_handle << modules;


### PR DESCRIPTION
Dear Sergey,

if you will have some time, here is a pull request for your consideration.


1) The pull request implements an option --multiple-files=n that makes binder to write the output into  files with names:  root-module-name + '.cpp' and  root-module-name + '_k.cpp', k=1..n. Basically that is the same as output with --single-file option but the sources  split into n pieces.

This is useful because:

 For some codebases of intermediate size having all bindings in a single file is not an option. 
 binder --single-file produces huge files. The compilation cannot be parallelized, it takes too much real-time to compile them and too much memory.

Using binder in a normal mode works fine, but the names of the produced files, their number and size vary depending on the used headers and binder setup.  This is not very practical when these files are stored in git or svn.

Binder with the implemented option produces multiple files with an approximately equal number of lines and the same names regardless of the used setup, solving both problems described above.
It works best with  --max-file-size set to some quite low number.


2) The codes were tested with the "standard" way of build with LLVM60
For the codes I was testing the option has allowed a significant reduction of real compilation time of produced bindings (~2min40s -> 40s) and a reduction of the peak memory consumption by gcc   (5.3Gb -> 1Gb) in comparison to the single file option.  



Best regards,
Andrii


