### PR TITLE
Linux CI: fast version with external LLVM using Fedora 

### DIFF
--- a/.github/workflows/fedora26/Dockerfile
+++ b/.github/workflows/fedora26/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM fedora:26
+
+#Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+#Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/fedora26/action.yaml
+++ b/.github/workflows/fedora26/action.yaml
@@ -1,0 +1,15 @@
+name: 'Compile binder'
+description: 'Binder'
+inputs:
+  theextraargument:   # an optional extra argument for docker run.
+    description: 'Extra docker argument'
+    required: true
+    default: 'World'
+outputs:
+  thestatus: # here we put the execution status 
+    description: 'The execution status'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.theextraargument }}

--- a/.github/workflows/fedora26/entrypoint.sh
+++ b/.github/workflows/fedora26/entrypoint.sh
@@ -5,8 +5,7 @@ cat /etc/issue
 yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
 yum -y install  libcxx-devel cmake make gcc gcc-c++
 yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
-git clone https://github.com/RosettaCommons/binder 
-cd binder 
+
 cmake CMakeLists.txt
 make
 out=$?

--- a/.github/workflows/fedora26/entrypoint.sh
+++ b/.github/workflows/fedora26/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+set -x
+uname -a 
+cat /etc/issue
+yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
+yum -y install  libcxx-devel cmake make gcc gcc-c++
+yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
+git clone https://github.com/RosettaCommons/binder 
+cd binder 
+cmake CMakeLists.txt
+make
+out=$?
+ldd source/binder
+ldd -u -r source/binder
+ctest . --output-on-failure 
+echo ::set-output name=out::$out

--- a/.github/workflows/fedora27/Dockerfile
+++ b/.github/workflows/fedora27/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM fedora:27
+
+#Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+#Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/fedora27/action.yaml
+++ b/.github/workflows/fedora27/action.yaml
@@ -1,0 +1,15 @@
+name: 'Compile binder'
+description: 'Binder'
+inputs:
+  theextraargument:   # an optional extra argument for docker run.
+    description: 'Extra docker argument'
+    required: true
+    default: 'World'
+outputs:
+  thestatus: # here we put the execution status 
+    description: 'The execution status'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.theextraargument }}

--- a/.github/workflows/fedora27/entrypoint.sh
+++ b/.github/workflows/fedora27/entrypoint.sh
@@ -5,8 +5,7 @@ cat /etc/issue
 yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
 yum -y install  libcxx-devel cmake make gcc gcc-c++
 yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
-git clone https://github.com/RosettaCommons/binder 
-cd binder 
+
 cmake CMakeLists.txt
 make
 out=$?

--- a/.github/workflows/fedora27/entrypoint.sh
+++ b/.github/workflows/fedora27/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+set -x
+uname -a 
+cat /etc/issue
+yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
+yum -y install  libcxx-devel cmake make gcc gcc-c++
+yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
+git clone https://github.com/RosettaCommons/binder 
+cd binder 
+cmake CMakeLists.txt
+make
+out=$?
+ldd source/binder
+ldd -u -r source/binder
+ctest . --output-on-failure 
+echo ::set-output name=out::$out

--- a/.github/workflows/fedora28/Dockerfile
+++ b/.github/workflows/fedora28/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM fedora:28
+
+#Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+#Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/fedora28/action.yaml
+++ b/.github/workflows/fedora28/action.yaml
@@ -1,0 +1,15 @@
+name: 'Compile binder'
+description: 'Binder'
+inputs:
+  theextraargument:   # an optional extra argument for docker run.
+    description: 'Extra docker argument'
+    required: true
+    default: 'World'
+outputs:
+  thestatus: # here we put the execution status 
+    description: 'The execution status'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.theextraargument }}

--- a/.github/workflows/fedora28/entrypoint.sh
+++ b/.github/workflows/fedora28/entrypoint.sh
@@ -5,8 +5,7 @@ cat /etc/issue
 yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
 yum -y install  libcxx-devel cmake make gcc gcc-c++
 yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
-git clone https://github.com/RosettaCommons/binder 
-cd binder 
+
 cmake CMakeLists.txt
 make
 out=$?

--- a/.github/workflows/fedora28/entrypoint.sh
+++ b/.github/workflows/fedora28/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+set -x
+uname -a 
+cat /etc/issue
+yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
+yum -y install  libcxx-devel cmake make gcc gcc-c++
+yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
+git clone https://github.com/RosettaCommons/binder 
+cd binder 
+cmake CMakeLists.txt
+make
+out=$?
+ldd source/binder
+ldd -u -r source/binder
+ctest . --output-on-failure 
+echo ::set-output name=out::$out

--- a/.github/workflows/fedora29/Dockerfile
+++ b/.github/workflows/fedora29/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM fedora:29
+
+#Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+#Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/fedora29/action.yaml
+++ b/.github/workflows/fedora29/action.yaml
@@ -1,0 +1,15 @@
+name: 'Compile binder'
+description: 'Binder'
+inputs:
+  theextraargument:   # an optional extra argument for docker run.
+    description: 'Extra docker argument'
+    required: true
+    default: 'World'
+outputs:
+  thestatus: # here we put the execution status 
+    description: 'The execution status'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.theextraargument }}

--- a/.github/workflows/fedora29/entrypoint.sh
+++ b/.github/workflows/fedora29/entrypoint.sh
@@ -5,8 +5,7 @@ cat /etc/issue
 yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
 yum -y install  libcxx-devel cmake make gcc gcc-c++
 yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
-git clone https://github.com/RosettaCommons/binder 
-cd binder 
+
 cmake CMakeLists.txt
 make
 out=$?

--- a/.github/workflows/fedora29/entrypoint.sh
+++ b/.github/workflows/fedora29/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+set -x
+uname -a 
+cat /etc/issue
+yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
+yum -y install  libcxx-devel cmake make gcc gcc-c++
+yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
+git clone https://github.com/RosettaCommons/binder 
+cd binder 
+cmake CMakeLists.txt
+make
+out=$?
+ldd source/binder
+ldd -u -r source/binder
+ctest . --output-on-failure 
+echo ::set-output name=out::$out

--- a/.github/workflows/fedora30/Dockerfile
+++ b/.github/workflows/fedora30/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM fedora:30
+
+#Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+#Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/fedora30/action.yaml
+++ b/.github/workflows/fedora30/action.yaml
@@ -1,0 +1,15 @@
+name: 'Compile binder'
+description: 'Binder'
+inputs:
+  theextraargument:   # an optional extra argument for docker run.
+    description: 'Extra docker argument'
+    required: true
+    default: 'World'
+outputs:
+  thestatus: # here we put the execution status 
+    description: 'The execution status'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.theextraargument }}

--- a/.github/workflows/fedora30/entrypoint.sh
+++ b/.github/workflows/fedora30/entrypoint.sh
@@ -5,8 +5,7 @@ cat /etc/issue
 yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
 yum -y install  libcxx-devel cmake make gcc gcc-c++
 yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
-git clone https://github.com/RosettaCommons/binder 
-cd binder 
+
 cmake CMakeLists.txt
 make
 out=$?

--- a/.github/workflows/fedora30/entrypoint.sh
+++ b/.github/workflows/fedora30/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+set -x
+uname -a 
+cat /etc/issue
+yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
+yum -y install  libcxx-devel cmake make gcc gcc-c++
+yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
+git clone https://github.com/RosettaCommons/binder 
+cd binder 
+cmake CMakeLists.txt
+make
+out=$?
+ldd source/binder
+ldd -u -r source/binder
+ctest . --output-on-failure 
+echo ::set-output name=out::$out

--- a/.github/workflows/fedora31/Dockerfile
+++ b/.github/workflows/fedora31/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM fedora:31
+
+#Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+#Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/fedora31/action.yaml
+++ b/.github/workflows/fedora31/action.yaml
@@ -1,0 +1,15 @@
+name: 'Compile binder'
+description: 'Binder'
+inputs:
+  theextraargument:   # an optional extra argument for docker run.
+    description: 'Extra docker argument'
+    required: true
+    default: 'World'
+outputs:
+  thestatus: # here we put the execution status 
+    description: 'The execution status'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.theextraargument }}

--- a/.github/workflows/fedora31/entrypoint.sh
+++ b/.github/workflows/fedora31/entrypoint.sh
@@ -5,8 +5,7 @@ cat /etc/issue
 yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
 yum -y install  libcxx-devel cmake make gcc gcc-c++
 yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
-git clone https://github.com/RosettaCommons/binder 
-cd binder 
+
 cmake CMakeLists.txt
 make
 out=$?

--- a/.github/workflows/fedora31/entrypoint.sh
+++ b/.github/workflows/fedora31/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+set -x
+uname -a 
+cat /etc/issue
+yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
+yum -y install  libcxx-devel cmake make gcc gcc-c++
+yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
+git clone https://github.com/RosettaCommons/binder 
+cd binder 
+cmake CMakeLists.txt
+make
+out=$?
+ldd source/binder
+ldd -u -r source/binder
+ctest . --output-on-failure 
+echo ::set-output name=out::$out

--- a/.github/workflows/fedora32/Dockerfile
+++ b/.github/workflows/fedora32/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM fedora:32
+
+#Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+#Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/fedora32/action.yaml
+++ b/.github/workflows/fedora32/action.yaml
@@ -1,0 +1,15 @@
+name: 'Compile binder'
+description: 'Binder'
+inputs:
+  theextraargument:   # an optional extra argument for docker run.
+    description: 'Extra docker argument'
+    required: true
+    default: 'World'
+outputs:
+  thestatus: # here we put the execution status 
+    description: 'The execution status'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.theextraargument }}

--- a/.github/workflows/fedora32/entrypoint.sh
+++ b/.github/workflows/fedora32/entrypoint.sh
@@ -5,8 +5,7 @@ cat /etc/issue
 yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
 yum -y install  libcxx-devel cmake make gcc gcc-c++
 yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
-git clone https://github.com/RosettaCommons/binder 
-cd binder 
+
 cmake CMakeLists.txt
 make
 out=$?

--- a/.github/workflows/fedora32/entrypoint.sh
+++ b/.github/workflows/fedora32/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+set -x
+uname -a 
+cat /etc/issue
+yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
+yum -y install  libcxx-devel cmake make gcc gcc-c++
+yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
+git clone https://github.com/RosettaCommons/binder 
+cd binder 
+cmake CMakeLists.txt
+make
+out=$?
+ldd source/binder
+ldd -u -r source/binder
+ctest . --output-on-failure 
+echo ::set-output name=out::$out

--- a/.github/workflows/fedora33/Dockerfile
+++ b/.github/workflows/fedora33/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM fedora:33
+
+#Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+#Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/fedora33/action.yaml
+++ b/.github/workflows/fedora33/action.yaml
@@ -1,0 +1,15 @@
+name: 'Compile binder'
+description: 'Binder'
+inputs:
+  theextraargument:   # an optional extra argument for docker run.
+    description: 'Extra docker argument'
+    required: true
+    default: 'World'
+outputs:
+  thestatus: # here we put the execution status 
+    description: 'The execution status'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.theextraargument }}

--- a/.github/workflows/fedora33/entrypoint.sh
+++ b/.github/workflows/fedora33/entrypoint.sh
@@ -5,8 +5,7 @@ cat /etc/issue
 yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
 yum -y install  libcxx-devel cmake make gcc gcc-c++
 yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
-git clone https://github.com/RosettaCommons/binder 
-cd binder 
+
 cmake CMakeLists.txt
 make
 out=$?

--- a/.github/workflows/fedora33/entrypoint.sh
+++ b/.github/workflows/fedora33/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -l
+set -x
+uname -a 
+cat /etc/issue
+yum -y install  git  zlib zlib-devel ncurses-devel  clang clang-devel clang-libs  llvm llvm-devel llvm-static
+yum -y install  libcxx-devel cmake make gcc gcc-c++
+yum -y install  pybind11-devel python3 python3-devel python2 python2-devel 
+git clone https://github.com/RosettaCommons/binder 
+cd binder 
+cmake CMakeLists.txt
+make
+out=$?
+ldd source/binder
+ldd -u -r source/binder
+ctest . --output-on-failure 
+echo ::set-output name=out::$out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,109 +4,101 @@ on:
 
 jobs:
 
-  compilejobfedora26:
+  compilejobFedora26:
     runs-on: ubuntu-latest
     name: Binder_on_Fedora26
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Compile
-      id: hello
+      id: compileindocker
       uses: ./.github/workflows/fedora26
-    # Use the output from the `hello` step
     - name: Get the output status
-      run: exit ${{ steps.hello.outputs.out }}
+      run: exit ${{ steps.compileindocker.outputs.out }}
 
-  compilejobfedora27:
+  compilejobFedora27:
     runs-on: ubuntu-latest
     name: Binder_on_Fedora27
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Compile
-      id: hello
+      id: compileindocker
       uses: ./.github/workflows/fedora27
-    # Use the output from the `hello` step
     - name: Get the output status
-      run: exit ${{ steps.hello.outputs.out }}
+      run: exit ${{ steps.compileindocker.outputs.out }}
 
-  compilejobfedora28:
+  compilejobFedora28:
     runs-on: ubuntu-latest
     name: Binder_on_Fedora28
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Compile
-      id: hello
+      id: compileindocker
       uses: ./.github/workflows/fedora28
-    # Use the output from the `hello` step
     - name: Get the output status
-      run: exit ${{ steps.hello.outputs.out }}
+      run: exit ${{ steps.compileindocker.outputs.out }}
 
-  compilejobfedora29:
+  compilejobFedora29:
     runs-on: ubuntu-latest
     name: Binder_on_Fedora29
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Compile
-      id: hello
+      id: compileindocker
       uses: ./.github/workflows/fedora29
-    # Use the output from the `hello` step
     - name: Get the output status
-      run: exit ${{ steps.hello.outputs.out }}
+      run: exit ${{ steps.compileindocker.outputs.out }}
 
-  compilejobfedora30:
+  compilejobFedora30:
     runs-on: ubuntu-latest
     name: Binder_on_Fedora30
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Compile
-      id: hello
+      id: compileindocker
       uses: ./.github/workflows/fedora30
-    # Use the output from the `hello` step
     - name: Get the output status
-      run: exit ${{ steps.hello.outputs.out }}
+      run: exit ${{ steps.compileindocker.outputs.out }}
 
 
-  compilejobfedora31:
+  compilejobFedora31:
     runs-on: ubuntu-latest
     name: Binder_on_Fedora31
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Compile
-      id: hello
+      id: compileindocker
       uses: ./.github/workflows/fedora31
-    # Use the output from the `hello` step
     - name: Get the output status
-      run: exit ${{ steps.hello.outputs.out }}
+      run: exit ${{ steps.compileindocker.outputs.out }}
 
 
-  compilejobfedora32:
+  compilejobFedora32:
     runs-on: ubuntu-latest
     name: Binder_on_Fedora32
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Compile
-      id: hello
+      id: compileindocker
       uses: ./.github/workflows/fedora32
-    # Use the output from the `hello` step
     - name: Get the output status
-      run: exit ${{ steps.hello.outputs.out }}
+      run: exit ${{ steps.compileindocker.outputs.out }}
 
 
-  compilejobfedora33:
+  compilejobFedora33:
     runs-on: ubuntu-latest
     name: Binder_on_Fedora33
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Compile
-      id: hello
+      id: compileindocker
       uses: ./.github/workflows/fedora33
-    # Use the output from the `hello` step
     - name: Get the output status
-      run: exit ${{ steps.hello.outputs.out }}
+      run: exit ${{ steps.compileindocker.outputs.out }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,112 @@
+on:
+ push:
+ pull_request:
+
+jobs:
+
+  compilejobfedora26:
+    runs-on: ubuntu-latest
+    name: Binder_on_Fedora26
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      id: hello
+      uses: ./.github/workflows/fedora26
+    # Use the output from the `hello` step
+    - name: Get the output status
+      run: exit ${{ steps.hello.outputs.out }}
+
+  compilejobfedora27:
+    runs-on: ubuntu-latest
+    name: Binder_on_Fedora27
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      id: hello
+      uses: ./.github/workflows/fedora27
+    # Use the output from the `hello` step
+    - name: Get the output status
+      run: exit ${{ steps.hello.outputs.out }}
+
+  compilejobfedora28:
+    runs-on: ubuntu-latest
+    name: Binder_on_Fedora28
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      id: hello
+      uses: ./.github/workflows/fedora28
+    # Use the output from the `hello` step
+    - name: Get the output status
+      run: exit ${{ steps.hello.outputs.out }}
+
+  compilejobfedora29:
+    runs-on: ubuntu-latest
+    name: Binder_on_Fedora29
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      id: hello
+      uses: ./.github/workflows/fedora29
+    # Use the output from the `hello` step
+    - name: Get the output status
+      run: exit ${{ steps.hello.outputs.out }}
+
+  compilejobfedora30:
+    runs-on: ubuntu-latest
+    name: Binder_on_Fedora30
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      id: hello
+      uses: ./.github/workflows/fedora30
+    # Use the output from the `hello` step
+    - name: Get the output status
+      run: exit ${{ steps.hello.outputs.out }}
+
+
+  compilejobfedora31:
+    runs-on: ubuntu-latest
+    name: Binder_on_Fedora31
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      id: hello
+      uses: ./.github/workflows/fedora31
+    # Use the output from the `hello` step
+    - name: Get the output status
+      run: exit ${{ steps.hello.outputs.out }}
+
+
+  compilejobfedora32:
+    runs-on: ubuntu-latest
+    name: Binder_on_Fedora32
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      id: hello
+      uses: ./.github/workflows/fedora32
+    # Use the output from the `hello` step
+    - name: Get the output status
+      run: exit ${{ steps.hello.outputs.out }}
+
+
+  compilejobfedora33:
+    runs-on: ubuntu-latest
+    name: Binder_on_Fedora33
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Compile
+      id: hello
+      uses: ./.github/workflows/fedora33
+    # Use the output from the `hello` step
+    - name: Get the output status
+      run: exit ${{ steps.hello.outputs.out }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 on:
  push:
  pull_request:
+ schedule:
+#Every 5 days at midnight 
+    - cron:  "0 0 1/5 * *"
 
 jobs:
 


### PR DESCRIPTION
Hi @lyskov  ,

this MR implements CI for Linux.

Note:
 - while the CI now attempts to run tests via cmake, the result of CI job is defined only with the result of the compilation.
That is why there is a third step in the CI.  Please note that the existing tests are not portable across compilers and platforms, so some logic should be added to the test suite before actually use the results of tests to define the outcome of the CI jobs. 

 - CI runs on push/pull and every 5 days on cron. Af far as I remember this works only on master branch.
 - Windows and mac can be added as well, but it makes sense to do that in another MR.
 - A version with full rebuild can be added as well, but again it makes more sense to have a separate MR for that.
 - There are many docker images from other distributions, so that would make sense to use some that are widespread in your community.  I can add some generic of redhat7/8 later, as that is used in HEP.


Best regards,
Andrii 