### PR TITLE
install: For Ubuntu 18.04+, recommend llvm-10 + clang-10

### DIFF
--- a/documentation/install.rst
+++ b/documentation/install.rst
@@ -104,11 +104,11 @@ For RHEL7/RHEL8/Fedora22+:
  ``yum install cmake3``
  
  
- For Ubuntu18+ run:
+ For Ubuntu18+ run, an example for LLVM/Clang 10:
  
  ``sudo apt-get update``
  
- ``sudo apt-get -y install  clang llvm  clang-dev*``
+ ``sudo apt-get -y install  clang-10 llvm-10 libclang-10-dev llvm-10-dev``
  
  ``sudo apt-get -y install  cmake make gcc g++``
 
@@ -132,5 +132,6 @@ Alternatively,the location of the llvm-config script could be set.
 
 ``cmake CMakeLists.txt   -DLLVMCONFIG=/usr/lib64/llvm7.0/bin/llvm-config``
 
+As an example with Ubuntu 18.04 and llvm-10:
 
-
+``cmake CMakeLists.txt   -DLLVM_DIR=/usr/lib/llvm-10 -DClang_DIR=/usr/lib/llvm-10``


### PR DESCRIPTION
Currently, `llvm` and `clang` point to LLVM/Clang 6 :(

* Adds `llvm-dev` and fixes spelling for `libclang-dev`
* Adds example for CMake configuration on Ubuntu