### PR TITLE
doc/config: Fix typo in default_call_guard URL

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -183,7 +183,7 @@ Config file directives:
 * ``default_member_rvalue_reference_return_value_policy``, specify return value policy for member functions returning r-value reference. Default
   is 'pybind11::return_value_policy::automatic'.
 
-* ``default_call_guard``, optionally specify a call guard applied to all function definitions. See `pybind11 documentation <http://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard`_. Default None.
+* ``default_call_guard``, optionally specify a call guard applied to all function definitions. See `pybind11 documentation <http://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard>`_. Default None.
 
 
 


### PR DESCRIPTION
From rich diff:
> ![image](https://user-images.githubusercontent.com/26719449/89111562-1d610f00-d425-11ea-8788-c17ec7bb5156.png)
