### PR TITLE
Add Includes for Nested Classes

### DIFF
--- a/source/class.cpp
+++ b/source/class.cpp
@@ -479,6 +479,10 @@ void ClassBinder::add_relevant_includes(IncludeSet &includes) const
 		for(auto const & i : pci->second) includes.add_include(O_annotate_includes ? i + " // +include_for_class" : i);
 	}
 
+	for_public_nested_classes([&includes](CXXRecordDecl *innerC) {
+		ClassBinder(innerC).add_relevant_includes(includes);
+	});
+
 	for(auto & m : prefix_includes ) binder::add_relevant_includes(m, includes, 0);
 	binder::add_relevant_includes(C, includes, 0);
 

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -1024,20 +1024,37 @@ std::string ClassBinder::bind_repr(Context &context)
 }
 
 
-string ClassBinder::bind_nested_classes(CXXRecordDecl const *EC, Context &context)
+void ClassBinder::for_public_nested_classes(const std::function<void(clang::CXXRecordDecl *C)>& f) const
 {
-	string c;
-	for(auto d = EC->decls_begin(); d != EC->decls_end(); ++d) {
-		if(CXXRecordDecl *C = dyn_cast<CXXRecordDecl>(*d) ) {
-			if( C->getAccess() == AS_public  and  is_bindable(C) ) {
-				//c += "\t// Binding " + C->getNameAsString() + ";\n";
-				ClassBinder b(C);
-				b.bind(context);
-				c += b.code();  c += '\n';
-				prefix_code_ += b.prefix_code();
+	for(auto d = C->decls_begin(); d != C->decls_end(); ++d) {
+		if(CXXRecordDecl *innerC = dyn_cast<CXXRecordDecl>(*d)) {
+			if(innerC->getAccess() == AS_public)
+				f(innerC);
+		}
+		else if(ClassTemplateDecl *ct = dyn_cast<ClassTemplateDecl>(*d)) {
+			if(ct->getAccess() == AS_public) {
+				for(auto s = ct->spec_begin(); s != ct->spec_end(); ++s) {
+					if(CXXRecordDecl *innerC = dyn_cast<CXXRecordDecl>(*s))
+						f(innerC);
+				}
 			}
 		}
 	}
+}
+
+
+string ClassBinder::bind_nested_classes(Context &context)
+{
+	string c;
+	for_public_nested_classes([&c, &context, this](CXXRecordDecl *innerC) {
+		if(is_bindable(innerC)) {
+			//c += "\t// Binding " + C->getNameAsString() + ";\n";
+			ClassBinder b(innerC);
+			b.bind(context);
+			c += b.code();  c += '\n';
+			prefix_code_ += b.prefix_code();
+		}
+	});
 	return c;
 }
 
@@ -1089,7 +1106,7 @@ void ClassBinder::bind(Context &context)
 	c += '\t' + R"(pybind11::class_<{}{}{}{}> cl({}, "{}", "{}");)"_format(qualified_name, maybe_holder_type, maybe_trampoline, maybe_base_classes(context), module_variable_name, python_class_name(C), generate_documentation_string_for_declaration(C)) + '\n';
 	//c += "\tpybind11::handle cl_type = cl;\n\n";
 
-	c += bind_nested_classes(C, context);
+	c += bind_nested_classes(context);
 
 	//if( C->isAbstract()  and  callback_structure) c += "\tcl.def(pybind11::init<>());\n";
 

--- a/source/class.hpp
+++ b/source/class.hpp
@@ -110,8 +110,11 @@ private:
 
 	void generate_prefix_code();
 
+	// do f for each nested public class
+	void for_public_nested_classes(const std::function<void(clang::CXXRecordDecl *C)>& f) const;
+
 	// generating bindings for public nested classes
-	string bind_nested_classes(clang::CXXRecordDecl const *EC, Context &context);
+	string bind_nested_classes(Context &context);
 
 	/// generate (if any) bindings for Python __str__ by using appropriate global operator<<
 	std::string bind_repr(Context &);


### PR DESCRIPTION
If an `+include_for_class` directive is present in the config file for a nested class, it should be processed while processing the relevant includes for the parent.

**Note:** This uses the `for_public_nested_classes` function added in #125, so #125  should be merged before this PR.