### PR TITLE
Fixing another test to make it work exacly the same on multiple systems

### DIFF
--- a/test/T11.override.hpp
+++ b/test/T11.override.hpp
@@ -12,7 +12,9 @@
 
 #ifndef _INCLUDED_T10_override_hpp_
 #define _INCLUDED_T10_override_hpp_
-
+/// Please note that some systems provide dual C++ ABI, which might affect the  generated code.
+/// The line below forces the usage of the older implementation of std::string on the systems with GNU libc.
+/// See  https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html for details.
 #define _GLIBCXX_USE_CXX11_ABI 0 
 #include <string>
 

--- a/test/T11.override.hpp
+++ b/test/T11.override.hpp
@@ -15,7 +15,7 @@
 /// Please note that some systems provide dual C++ ABI, which might affect the  generated code.
 /// The line below forces the usage of the older implementation of std::string on the systems with GNU libc.
 /// See  https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html for details.
-#define _GLIBCXX_USE_CXX11_ABI 0 
+/// #define _GLIBCXX_USE_CXX11_ABI 0 
 #include <string>
 
 class Base

--- a/test/T11.override.hpp
+++ b/test/T11.override.hpp
@@ -13,7 +13,7 @@
 #ifndef _INCLUDED_T10_override_hpp_
 #define _INCLUDED_T10_override_hpp_
 
-#include <memory>
+#define _GLIBCXX_USE_CXX11_ABI 0 
 #include <string>
 
 class Base


### PR DESCRIPTION
To match the reference source one should use 

```
#define  _GLIBCXX_USE_CXX11 0
```
this assures usage of  ``string`` instead of  `` _cxx11::string`` 

``<memory>`` header is not needed.


