### PR TITLE
Added clang-format config (for consideration)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,18 @@
+---
+BasedOnStyle:  LLVM
+AlignTrailingComments: false
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+ColumnLimit:     0
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+BreakConstructorInitializersBeforeComma: false
+Standard:        Cpp11
+IndentWidth:     4
+TabWidth:        4
+UseTab:          Always
+BreakBeforeBraces: Attach
+#BreakBeforeBraces: Allman
+SpacesInParentheses: true
+SpaceInEmptyParentheses: false
+...
+


### PR DESCRIPTION
Hi @lyskov ,

here is an attempt to have a clang-format config that would match the observed formatting rules in the code (e.g. tabs).

If you find it reasonable, and  the `clang-format  -i source/*p` command  is executed on the reference platform once: 

 - the need to check or adjust formatting in any merge request will disappear. 

 - practically the formatting check can be integrated into CI. Again, no need for a manual check.

Also, the format file is not my personal preferences (don't have any), but an attempt to match the existing rules. The idea of this MR is just to have any formatting config so the code formatting can be done  (semi-)automatically.


Bets regards,

Andrii

P.S. I could not deduce the prefered style for the breaks before braces from the code. Sometimes it looks like "Attach", i.e. no break before the brace, sometimes it is "Allman", i.e. always break. Therefore left a commented line.
