### PR TITLE
Checks of spelling and fixes in docs

### DIFF
--- a/documentation/basics.rst
+++ b/documentation/basics.rst
@@ -48,7 +48,7 @@ do so.
 Running the Binder
 ------------------
 
-After the input file is ready the next step is to run Binder. Assuming that our include file conatining all headers from the
+After the input file is ready the next step is to run Binder. Assuming that our include file containing all headers from the
 project is named as ``all_includes.hpp`` it could be done as:
 
 .. code-block:: bash
@@ -61,7 +61,7 @@ project is named as ``all_includes.hpp`` it could be done as:
 
 
 Note that we have to specify project-wide include path so Binder could find includes specifies in ``all_includes.hpp`` as well
-as path to any aditional C++ include headers that is used in project.
+as path to any additional C++ include headers that is used in project.
 
 Most big project will probably require fine tunning of bindings generation process. This can be done by creating Binder config
 file and specifying it when calling Binder as ``--config my_project.config``. For detailed reference of config file options

--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -161,27 +161,27 @@ Config file directives:
 
 
 * ``default_static_pointer_return_value_policy``, specify return value policy for static functions returning pointer to objects. Default is
-  'pybind11::return_value_policy::automatic'.
+  `pybind11::return_value_policy::automatic`.
 
 
 * ``default_static_lvalue_reference_return_value_policy``, specify return value policy for static functions returning l-value reference. Default
-  is 'pybind11::return_value_policy::automatic'.
+  is `pybind11::return_value_policy::automatic`.
 
 
 * ``default_static_rvalue_reference_return_value_policy``, specify return value policy for static functions returning r-value reference. Default
-  is 'pybind11::return_value_policy::automatic'.
+  is `pybind11::return_value_policy::automatic`.
 
 
 * ``default_member_pointer_return_value_policy``, specify return value policy for member functions returning pointer to objects. Default is
-  'pybind11::return_value_policy::automatic'.
+  `pybind11::return_value_policy::automatic`.
 
 
 * ``default_member_lvalue_reference_return_value_policy``, specify return value policy for member functions returning l-value reference. Default
-  is 'pybind11::return_value_policy::automatic'.
+  is `pybind11::return_value_policy::automatic`.
 
 
 * ``default_member_rvalue_reference_return_value_policy``, specify return value policy for member functions returning r-value reference. Default
-  is 'pybind11::return_value_policy::automatic'.
+  is `pybind11::return_value_policy::automatic`.
 
 * ``default_call_guard``, optionally specify a call guard applied to all function definitions. See `pybind11 documentation <http://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard>`_. Default None.
 

--- a/documentation/debugging.rst
+++ b/documentation/debugging.rst
@@ -1,5 +1,5 @@
 Debugging and troubleshooting 
-##########
+#############################
 
 This section is dedicated to the description of problems that 
 might appear while creating the python bindings with binder and the ways to avoid them.
@@ -13,7 +13,7 @@ Inconsistencies
 
 Binder moves down the ``all_includes_file`` file sequentially, sometimes ending up with errors.  
 This is almost always caused by the ``all_includes_file`` being
-different between runs.  The order shouldn't be important, but nail it down to at least be
+different between runs.  The order should not be important, but nail it down to at least be
 consistent, and then move on to the next step.
 
 --------------
@@ -21,7 +21,7 @@ Build failures
 --------------
 
 Even when the bindings were generated successfully,  there might be compilation errors when building the modules from the generated sources.
-Quite often  the errors are caused by the implementation of the С++standard library, when the headers of the standard library 
+Quite often  the errors are caused by the implementation of the C++ standard library, when the headers of the standard library 
 include each other, or include implementation-specific headers. 
 Many cases like that are already handled in the functions from the ``source/types.cpp`` file, 
 using the knowledge of the existing STL implementations.
@@ -38,7 +38,7 @@ For instance, the compilation could fail with the following error messages:
 
     FAILED: CMakeFiles/statvec.dir/std/complex.o 
     In file included from std/complex.cpp:1:0:
-    /usr/include/c++/7/bits/stl_construct.h: In function ‘void std::_Destroy(_ForwardIterator, _ForwardIterator)’:
+    /usr/include/c++/7/bits/stl_construct.h: In function 'void std::_Destroy(_ForwardIterator, _ForwardIterator)':
     **long and cryptic error message**
 
 The ways to handle this error:
@@ -47,62 +47,63 @@ The ways to handle this error:
     more information on the binded classes.
 
 2.  Since the includes from the ``bits`` directory should not appear in the generated code,  one can grep for ``bits`` in the generated codes, 
-   i.e. ``grep -r "bits" cmake_bindings/*`` could yield:
+    i.e. ``grep -r "bits" cmake_bindings/*`` could yield:
 
-.. code-block:: console
 
-    cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Construct
-    cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Destroy
-    cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Destroy_aux
-    cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Destroy_aux<true>::__destroy
-    cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Destroy_n_aux
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_copy
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_copy<false>::__uninit_copy
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_copy<true>::__uninit_copy
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_copy_a
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_1
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n_1
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n_1<false>::__uninit_default_n
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n_1<true>::__uninit_default_n
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n_a
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_novalue_1
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_novalue_n_1
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_fill
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_fill_n
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_move_if_noexcept_a
-    cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::uninitialized_copy
+    .. code-block:: console
+
+      cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Construct
+      cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Destroy
+      cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Destroy_aux
+      cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Destroy_aux<true>::__destroy
+      cmake_bindings/std/complex.cpp:#include <bits/stl_construct.h> // std::_Destroy_n_aux
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_copy
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_copy<false>::__uninit_copy
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_copy<true>::__uninit_copy
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_copy_a
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_1
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n_1
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n_1<false>::__uninit_default_n
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n_1<true>::__uninit_default_n
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_n_a
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_novalue_1
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_default_novalue_n_1
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_fill
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_fill_n
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::__uninitialized_move_if_noexcept_a
+      cmake_bindings/std/complex.cpp:#include <bits/stl_uninitialized.h> // std::uninitialized_copy
   
-The important information in the output is the ``std::`` types/functions without the leading underscores.
- Those are STL-implementation independent types/functions that should be defined elsewhere, not in the headers from the ``bits`` directory.
-In this particular example, the function of interest is ``std::uninitialized_copy``.  
+    The important information in the output is the ``std::`` types/functions without the leading underscores.
+    Those are STL-implementation independent types/functions that should be defined elsewhere, not in the headers from the ``bits`` directory.
+    In this particular example, the function of interest is ``std::uninitialized_copy``.  
 
-A quick search in the C++ documentation at https://en.cppreference.com or other resources tells that this function is defined in the <memory> header.
-Therefore, this information should be hardcoded into the binder.
+    A quick search in the C++ documentation at https://en.cppreference.com or other resources tells that this function is defined in the <memory> header.
+    Therefore, this information should be hardcoded into the binder.
 
 
 3.  The internal binder function that handles the STL library mappings is located in ``source/types.cpp``:``add_relevant_include_for_decl``.  
-Briefly, the function has a map with the STL headers and the types those contain. That should look similar to this:
+    Briefly, the function has a map with the STL headers and the types those contain. That should look similar to this:
 
-.. code-block:: python
+    .. code-block::  C++
 
-    { "<algorithm>", {"std::move_backward", "std::iter_swap", "std::min"} },
-    { "<exception>", {"std::nested_exception"} }
-
-
-If there is a need to make a simple change, like in our case,  the map for the ``<memory>`` can be added like this:
-
-.. code-block:: python
-
-    { "<algorithm>", {"std::move_backward", "std::iter_swap", "std::min"} },
-    { "<exception>", {"std::nested_exception"} },
-    { "<memory>", {"std::uninitialized_copy"} },
+      { "<algorithm>", {"std::move_backward", "std::iter_swap", "std::min"} },
+      { "<exception>", {"std::nested_exception"} }
 
 
-In addition to that, to ensure a better portability, some of the implementation-specific headers are replaced in binder with the standard ones.
-The map that holds the replacements is located in the ``source/types.cpp`` file as well. It should look similar to this:
+    If there is a need to make a simple change, like in our case,  the map for the ``<memory>`` can be added like this:
 
-.. code-block:: python
+    .. code-block::  C++
+
+      { "<algorithm>", {"std::move_backward", "std::iter_swap", "std::min"} },
+      { "<exception>", {"std::nested_exception"} },
+      { "<memory>", {"std::uninitialized_copy"} },
+
+
+    In addition to that, to ensure a better portability, some of the implementation-specific headers are replaced in binder with the standard ones.
+    The map that holds the replacements is located in the ``source/types.cpp`` file as well. It should look similar to this:
+
+    .. code-block::  C++
 
        static vector< std::pair<string, string> > const include_map = {
         make_pair("<bits/ios_base.h>",     "<ios>"),
@@ -115,4 +116,4 @@ The map that holds the replacements is located in the ``source/types.cpp`` file 
     In some cases, many iterations of the described procedure will be needed till all the STL types/functions will be mapped to the correct includes. 
     
     If this fixes your problem please let us know, or make a pull request!
-    
+

--- a/documentation/examples.rst
+++ b/documentation/examples.rst
@@ -36,8 +36,8 @@ folder.
 Their names are self explanatory, but I would highly recommend that for your
 own applications that you follow the ``python`` & ``cmake`` workflow.
 
-Each script's final running lines also imports the ``test_struct`` module and
-prints a variable or two of it to prove that it's working.
+Each script\'s final running lines also imports the ``test_struct`` module and
+prints a variable or two of it to prove that it is working.
 
 
 This example/tutorial will walk you through the step-by-step of both
@@ -45,11 +45,11 @@ This example/tutorial will walk you through the step-by-step of both
 to be done to generate bindings.  Upon understanding the more manual ``bash``
 method, the ``cmake`` code should make much more sense.
 
-The rest of "Simple struct" will also take you through generating pybind11 stl
+The rest of \"Simple struct\" will also take you through generating pybind11 stl
 bindings (like making bindings for `std::vector` -> python list) and how to use
-binder's bindings for `std::vector` to access `std::vector` objects without
+binder\'s bindings for `std::vector` to access `std::vector` objects without
 converting them to python lists.  This allows us to benefit from the speed of
-c++!
+C++!
 
 
 Building bindings basics
@@ -191,18 +191,18 @@ You may notice how ever that this will still fail:
 
     python3 -c "import sys; sys.path.append('.'); import test_struct; f = test_struct.testers.test_my_struct(); print(f.a_float); f.add_float(); print(f.a_float); print(f.a_vector)"
 
-This fails because python doesn't understand how to interact with the std
+This fails because python does not understand how to interact with the std
 library classes like ``std::vector``. You can get around this by remaking your
 bindings with this config file. **However**, you must note that when you are
 returning vectors into your python environment, or pushing lists to the c++
-side, there is a performance penalty when pybind converts from ``python
+side, there is a performance penalty when pybind11 converts from ``python
 list[]`` -> ``std::vector``, and vice-versa. This can be a problem when dealing
 with larger lists/vectors.
 
 If performance is critical, it is advised that most work is done via c++,
-and you just use python as the 'glue'. For example, the following command
-doesn't fail, because python never has to 'see' the std::vector and all of
-the work is done in the c++ layer.
+and you just use python as the \"glue\". For example, the following command
+does not fail, because python never has to \"see\" the std::vector and all of
+the work is done in the C++ layer.
 
 .. code-block:: console
 

--- a/documentation/install.rst
+++ b/documentation/install.rst
@@ -1,6 +1,7 @@
 Installation
 ============
-**Binder** is written in C++11 and must be built before use. This page describes the steps for the build process. Please note that installiation require up to ~2.6+ Gb of free disk space.
+**Binder** is written in C++11 and must be built before use. This page describes the steps for the build process. 
+Please note that installation require up to ~2.6+ Gb of free disk space.
 
 
 
@@ -11,10 +12,10 @@ The following tools need to be present in order to build and use **Binder**
 - CMake, https://cmake.org
   - static compilation requires version 3.13 or above, see below
 - Pybind11, RosettaCommons fork: https://github.com/RosettaCommons/pybind11
-- [optional] Ninja (or you can use `make` by ommiting `-G Ninja` command below)
+- [optional] Ninja (or you can use `make` by omitting `-G Ninja` command below)
 
 
-Binder has experimental support for being *statically compiled* on CentOS 8,
+Binder has experimental support for being *statically compiled* on CentOS8,
 which additionally requires:
 
 - `libclang-static-build`: https://github.com/deech/libclang-static-build
@@ -27,10 +28,13 @@ may not be compatible with the header files on the system Binder where is run.
 
 Building
 ********
-The steps below are encoded in `binder/build.py` and `binder/build-and-run-tests.py` files so for default install you can just run `build-and-run-tests.py` script directly. This section describes how to build a dynamically-linked ``binder`` executable. To *statically* compile binder, see :ref:`building-static`.
+The steps below are encoded in `binder/build.py` and `binder/build-and-run-tests.py` 
+files so for default install you can just run `build-and-run-tests.py` script directly. 
+This section describes how to build a dynamically-linked ``binder`` executable. 
+To *statically* compile binder, see :ref:`building-static`.
 
 
-#. To build Binder exectute the following command sequence in shell (replace ``$HOME/prefix`` and ``$HOME/binder`` with your paths):
+#. To build Binder execute the following command sequence in shell (replace ``$HOME/prefix`` and ``$HOME/binder`` with your paths):
 
 .. code-block:: bash
 
@@ -66,15 +70,15 @@ The steps below are encoded in `binder/build.py` and `binder/build-and-run-tests
   mkdir $HOME/prefix/build && cd $HOME/prefix/build
   cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_EH=1 -DLLVM_ENABLE_RTTI=ON ../llvm && ninja
 
-  # At this point, if all above steps is succeseful, binder should be at
+  # At this point, if all above steps is successful, binder should be at
   # $HOME/prefix/build/bin/binder
 
 
 Installation with pre-installed LLVM 
-============
+====================================
 Requirements
 ************
-The basic dependencies for this type of installanion are very similar to these described above and include:
+The basic dependencies for this type of installation are very similar to these described above and include:
 
 - CMake, version 3.4.3 or higher from https://cmake.org 
 - C++ compiler with c++11 support, e.g. gcc from  https://gcc.gnu.org/  
@@ -83,69 +87,86 @@ The basic dependencies for this type of installanion are very similar to these d
 - clang  with development packages (headers)
 
 The installation process of the required packages varies from system to system.
-On the RHEL7/RHEL8/Fedora22+/Ubuntu18+  systems binder can be compilled with the llvm, clang and dependent packages available 
+On the RHEL7/RHEL8/Fedora22+/Ubuntu18+  systems binder can be compiled with the llvm, clang and dependent packages available 
 for these systems from their default repositories
  
  
 For RHEL7/RHEL8/Fedora22+:
 
 - To install the needed packages   run as root 
+
+  .. code-block:: console
  
-  ``yum install clang clang-devel llvm-devel llvm-static clang-libs``
+    yum install clang clang-devel llvm-devel llvm-static clang-libs
   
 - If a newer or specific version of the llvm/clang is needed, it can be installed  as root
   
-  ``yum install clang8.0 clang8.0-devel llvm8.0-devel llvm8.0-static clang8.0-libs``
+  .. code-block:: console
+  
+     yum install clang8.0 clang8.0-devel llvm8.0-devel llvm8.0-static clang8.0-libs
    
   to obtain a specific version (8.0 in this case).
     
 - If the option above is not sufficient, or the available packages are outdated, for the 
   CentOS/RHEL/Fedora and compatible systems the llvm-toolset-7.0 toolset (or later) from
-  https://www.softwarecollections.org/en/scls/rhscl/llvm-toolset-7.0/ provides . Run as root
+  https://www.softwarecollections.org/en/scls/rhscl/llvm-toolset-7.0/ provides LLVM of version 7.0. 
+  To install it run as root
   
-  ``yum install llvm-toolset-7.0* ``
+  .. code-block:: console
+    
+    yum install llvm-toolset-7.0* 
   
   Then the compilation can be performed using the following shell
- 
-  ``scl enable llvm-toolset-7 bash``
+  
+  .. code-block:: console
+  
+    scl enable llvm-toolset-7.0 bash
  
 - Please note that binder requires cmake of version 3, therefore for some older systems
   package cmake3 should be installed and used instead of cmake.
+  
+  .. code-block:: console
+    
+    yum install cmake3
  
- ``yum install cmake3``
  
- 
- For Ubuntu18+ run, an example for LLVM/Clang 10:
- 
- ``sudo apt-get update``
- 
- ``sudo apt-get -y install  clang-10 llvm-10 libclang-10-dev llvm-10-dev``
- 
- ``sudo apt-get -y install  cmake make gcc g++``
+For Ubuntu18+ run, an example for LLVM/Clang 10:
+  
+  .. code-block:: console
+    
+    sudo apt-get update
+    sudo apt-get -y install  clang-10 llvm-10 libclang-10-dev llvm-10-dev
+    sudo apt-get -y install  cmake make gcc g++
 
 
 Building
 ********
 To build ``binder`` run
 
-``cmake CMakeLists.txt -DCMAKE_INSTALL_PREFIX:PATH=/home/user/whereiwanttohaveit/``
+.. code-block:: console
 
-``make``
-
-``make install``
+   cmake CMakeLists.txt -DCMAKE_INSTALL_PREFIX:PATH=/home/user/whereiwanttohaveit/
+   make
+   make install
 
 To perform the build with a specific version of LLVM, the location of LLVM and CLANG directories 
 should be set simultaneously via the location of their cmake configurations, i.e.
 
-``cmake CMakeLists.txt   -DLLVM_DIR=/usr/lib64/llvm8.0/lib/cmake/llvm -DClang_DIR=/usr/lib64/llvm8.0/lib/cmake/clang``
+.. code-block:: console
+   
+   cmake CMakeLists.txt   -DLLVM_DIR=/usr/lib64/llvm8.0/lib/cmake/llvm -DClang_DIR=/usr/lib64/llvm8.0/lib/cmake/clang
 
-Alternatively,the location of the llvm-config script could be set.
+Alternatively, the location of the llvm-config script could be set.
 
-``cmake CMakeLists.txt   -DLLVMCONFIG=/usr/lib64/llvm7.0/bin/llvm-config``
+.. code-block:: console
+   
+   cmake CMakeLists.txt   -DLLVMCONFIG=/usr/lib64/llvm7.0/bin/llvm-config
 
 As an example with Ubuntu 18.04 and llvm-10:
 
-``cmake CMakeLists.txt   -DLLVM_DIR=/usr/lib/llvm-10 -DClang_DIR=/usr/lib/llvm-10``
+.. code-block:: console
+
+   cmake CMakeLists.txt   -DLLVM_DIR=/usr/lib/llvm-10 -DClang_DIR=/usr/lib/llvm-10
 
 
 Using ``binder`` built with pre-installed LLVM
@@ -154,46 +175,55 @@ Using ``binder`` built with pre-installed LLVM
 Under some circumstances (e.g. on system where the default compiller is not clang)
 ``binder`` might emit error messages like 
 
-```
-/usr/lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/bits/cxxabi_init_exception.h:38:10: fatal error: 'stddef.h' file not found
-#include <stddef.h>
-         ^~~~~~~~~~
-1 error generated.
-```
-and similar, see https://clang.llvm.org/docs/FAQ.html. To fix this issue, ``binder`` should be pointed to the location of the
-appropriate clang includes. This can be archieved using the clang options that are passed to binder after ``--`` flag, e.g.\
+.. code-block:: console
 
-```
-binder ...binder...options...  -- -x c++  ...other...options...   -iwithsysroot/where/the/directory/with/includes/is/
-```
+   /usr/lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/bits/cxxabi_init_exception.h:38:10: fatal error: 'stddef.h' file not found
+   #include <stddef.h>
+            ^~~~~~~~~~
+   1 error generated.
+
+and similar, see https://clang.llvm.org/docs/FAQ.html. To fix this issue, ``binder`` should be pointed to the location of the
+appropriate clang includes. This can be archived using the clang options that are passed to binder after ``--`` flag, e.g.\
+
+.. code-block:: console
+   
+   binder ...binder...options...  -- -x c++  ...other...options...   -iwithsysroot/where/the/directory/with/includes/is/
 
 See https://clang.llvm.org/docs/ClangCommandLineReference.html for details.
-If ``binder` was build withsome older versions of LLVM, one could also set the location of the headers with the
+If ``binder`` was build with some older versions of LLVM, one could also set the location of the headers with the
 ``C_INCLUDE_PATH`` and  ``CPLUS_INCLUDE_PATH`` environment variables, e.g.
-```
-export CPLUS_INCLUDE_PATH=/where/the/directory/with/includes/is/
-```
+
+.. code-block:: console
+
+   export CPLUS_INCLUDE_PATH=/where/the/directory/with/includes/is/
+
 
 
 .. _building-static:
 
-Building Statically
-*******************
+Building Statically (Linux only)
+********************************
 
-First, install version CMake version 3.13 or above, which is required to build `libclang-static-build`. CentOS 8's version is too old, so install a binary distribution of CMake from https://cmake.org/.
+The first step in the static build is to build the ``libclang`` statically following the instructions 
+from https://github.com/deech/libclang-static-build. For this quite a recent version of cmake is needed (3.13+). 
+If the version of cmake form the used distribution is too old (e.g.  as in the CentOS8 )  a precompilled 
+package from the CMake site from https://cmake.org/ can be used instead.
 
-Then build `libclang-static-build` per the official instructions: https://github.com/deech/libclang-static-build
+The static build requires some other static libraries to be present in the system.
+For the CentOS8  install ``libstdc++-static`` and ``ncurses-compat-libs`` runnign as root:
 
-Then install the following packages on CentOS 8:
-
- ``sudo yum install libstdc++-static ncurses-compat-libs``
+.. code-block:: console
+   
+   sudo yum install libstdc++-static ncurses-compat-libs
 
 
 Set the environment variable ``LIBCLANG_STATIC_BUILD_DIR`` to the path of
 `libclang-static-build`. Then build ``binder`` with the following procedure:
 
- ``cmake CMakeLists.txt -DSTATIC=on -DLLVMCONFIG="${LIBCLANG_STATIC_BUILD_DIR}/build/_deps/libclang_prebuilt-src/bin/llvm-config" -DLLVM_LIBRARY_DIR="${LIBCLANG_STATIC_BUILD_DIR}/lib" -DCMAKE_INSTALL_PREFIX:PATH=/home/user/whereiwanttohaveit/``
+.. code-block:: console
 
- ``make``
+   cmake CMakeLists.txt -DSTATIC=on -DLLVMCONFIG="${LIBCLANG_STATIC_BUILD_DIR}/build/_deps/libclang_prebuilt-src/bin/llvm-config" -DLLVM_LIBRARY_DIR="${LIBCLANG_STATIC_BUILD_DIR}/lib" -DCMAKE_INSTALL_PREFIX:PATH=/home/user/whereiwanttohaveit/
 
- ``make install``
+   make
+
+   make install

--- a/documentation/testing.rst
+++ b/documentation/testing.rst
@@ -7,18 +7,24 @@ located in the ``test`` subdirectory.
 The first implementation is located inside the script ``build-and-run-tests.py`` and is
 designed to be used for the builds inside the LLVM source tree. This implementation 
 is briefly described above.
-The second implementation uses ``cmake/ctest`` and is used in the CI with the extrnal LLVM 
+The second implementation uses ``cmake/ctest`` and is used in the CI with the external LLVM 
 installation. To configure this testing suite, use
-``cmake ...  -DBINDER_ENABLE_TEST=ON ...``
+
+.. code-block:: bash
+
+  cmake ...  -DBINDER_ENABLE_TEST=ON ...
 
 Multiple python versions can be and should be used in parallel. The versions are set as a 
 comma-separated list passed by the ``BINDER_TEST_PYTHON_VERSIONS`` option. The default list is ``0,2,3``.
-The Python version "0" corresponds to a "plain diff" of the output vs. reference. 
+The Python version \"0\" corresponds to a \"plain diff\" of the output vs. reference. 
 The versions of Python2/Python3 will be the first versions found by cmake, see 
 https://cmake.org/cmake/help/latest/module/FindPython.html and https://cmake.org/cmake/help/latest/module/FindPython3.html
 for your cmake version. 
 To use specific python versions one can use the following
-``cmake .... -DBINDER_TEST_PYTHON_VERSIONS=0,2.7.15,3.8.0,3.7.0 ...``
+
+.. code-block:: bash
+  
+  cmake .... -DBINDER_TEST_PYTHON_VERSIONS=0,2.7.15,3.8.0,3.7.0 ...
 
 The generated codes will be compiled and loaded using the corresponding interpreter.
 With an option ``-DBINDER_MOCK_TEST=ON`` one can mock the code generation by binder. 


### PR DESCRIPTION
Hi @lyskov ,

here are some fixes for docs.
Briefly I've fixed some indentation, spelling and tried to use more ``code-block::``. No changes to the text part from 
slightly more smooth description of the static build.


Best regards,

Andrii