### PR TITLE
Remove semicolons in module_header

### DIFF
--- a/source/context.cpp
+++ b/source/context.cpp
@@ -354,9 +354,9 @@ const char * module_header = R"_(
 {}
 #ifndef BINDER_PYBIND11_TYPE_CASTER
 	#define BINDER_PYBIND11_TYPE_CASTER
-	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
-	PYBIND11_DECLARE_HOLDER_TYPE(T, T*);
-	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>);
+	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
 )_";


### PR DESCRIPTION
Hi @lyskov ,

here is a tiny, completely non-urgent pull request.

The idea is to remove semicolons in "module_header" to prevent gcc warnings when compiling with -Wpedantic.

The messages I see look like this:

```
 warning: extra ‘;’ [-Wpedantic]
  PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
                                                     ^
 warning: extra ‘;’ [-Wpedantic]
  PYBIND11_DECLARE_HOLDER_TYPE(T, T*);
                                     ^
 warning: extra ‘;’ [-Wpedantic]
  PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>);
                                             ^
```
There are two other warnings:

```
 warning: ISO C++11 requires at least one argument for the "..." in a variadic macro
  PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>);
                                                    ^
 warning: ISO C++11 requires at least one argument for the "..." in a variadic macro
  PYBIND11_DECLARE_HOLDER_TYPE(T, T*);
```
however these are inside the `pybind11` code.


Best regards,

Andrii


