### PR TITLE
Inheritance of inner classes

### DIFF
--- a/source/class.cpp
+++ b/source/class.cpp
@@ -12,8 +12,10 @@
 
 #include <binder.hpp>
 #include <class.hpp>
+#include <dependency.hpp>
 #include <function.hpp>
 #include <enum.hpp>
+#include <memory>
 #include <type.hpp>
 #include <util.hpp>
 
@@ -1091,6 +1093,10 @@ string ClassBinder::bind_nested_classes(Context &context)
 			b.bind(context);
 			c += b.code();  c += '\n';
 			prefix_code_ += b.prefix_code();
+			// make context aware of innerC
+			// (this registers innerC with context with C as a dependency)
+			BinderOP bop = std::shared_ptr<Binder>( new Dependency( innerC, C ) );
+			context.add( bop );
 		}
 	});
 

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -225,7 +225,11 @@ void Context::bind(Config const &config)
 
 		outs() << "Generate bindings, pass " << pass << "...\n";
 
-		for(auto & sp : binders) {
+		// Context::add might invalidate iterators over binders
+		// when called inside b.bind(*this)
+		// => need to loop over a copy here
+		auto binders_ = binders;
+		for(auto & sp : binders_) {
 			Binder & b( *sp );
 			if( !b.is_binded()  and  b.bindable() and  b.binding_requested() ) {
 				//outs() << "Binding: " << b.id() /*named_decl()->getQualifiedNameAsString()*/ << "\n";

--- a/source/dependency.hpp
+++ b/source/dependency.hpp
@@ -1,0 +1,56 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+//
+// All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+/// @file  binder/dependency.hpp
+/// @brief Dependency: A Binder class for dependency management
+
+#ifndef _INCLUDED_dependency_hpp_
+#define _INCLUDED_dependency_hpp_
+
+#include <class.hpp>
+#include <context.hpp>
+
+namespace binder {
+
+/// Dependency Binder class - helps managing dependencies between type bindings
+/// The Dependency class indicates that the binding for a type is provided by
+/// the binding of another class (the dependency).
+/// (Prime example being an inner class whose binding is provided by its enclosing class)
+/// The Dependency class does not generate any binding code!
+class Dependency : public Binder {
+  public:
+	Dependency( clang::CXXRecordDecl const *c, clang::CXXRecordDecl const *dependency ) : C( c ) {
+		dependencies_.push_back( dependency );
+	};
+
+	/// Generate string id that uniquly identify C++ binding object. For functions this is function prototype and for classes forward declaration.
+	string id() const override {
+		return class_qualified_name( C );
+	};
+
+	// return Clang AST NamedDecl pointer to original declaration used to create this Binder
+	clang::NamedDecl const *named_decl() const override { return C; };
+
+	bool bindable() const override { return false; }; // dependencies are not bindable
+
+	virtual void request_bindings_and_skipping( Config const &config ) override{}; // nothing to do
+
+	void add_relevant_includes( IncludeSet &includes ) const override{}; // nothing to do
+
+	void bind( Context & ) override{}; // nothing to do
+
+	std::vector<clang::CXXRecordDecl const *> dependencies() const override { return dependencies_; };
+
+  private:
+	clang::CXXRecordDecl const *C;
+
+	// vector of classes in which current class depend to be binded (usually base classes)
+	std::vector<clang::CXXRecordDecl const *> dependencies_;
+};
+
+} // namespace binder
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,6 +92,7 @@ set( binder_tests
          T15.copy
          T15.inner_class
          T15.inner_class.fwd
+         T15.inner_class.inheritance
          T17.anonymous
          T20.template
          T30.include

--- a/test/T15.inner_class.inheritance.hpp
+++ b/test/T15.inner_class.inheritance.hpp
@@ -1,0 +1,20 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+
+#ifndef T15_INNER_CLASS_INHERITANCE_H
+#define T15_INNER_CLASS_INHERITANCE_H
+
+/// @file   binder/test/T15.inner_class.inheritance.hpp
+/// @brief  Binder self-test file. Tests for bindings of classes inheriting from inner classes.
+
+struct outer {
+	struct inner {
+		int a;
+	};
+};
+
+struct outer2 : public outer::inner {
+	double b;
+};
+
+#endif

--- a/test/T15.inner_class.inheritance.ref
+++ b/test/T15.inner_class.inheritance.ref
@@ -1,0 +1,102 @@
+// File: T15_inner_class_inheritance.cpp
+#include <T15.inner_class.inheritance.hpp> // outer
+#include <T15.inner_class.inheritance.hpp> // outer::inner
+#include <sstream> // __str__
+
+#include <pybind11/pybind11.h>
+#include <functional>
+#include <string>
+
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+	#define BINDER_PYBIND11_TYPE_CASTER
+	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
+#endif
+
+void bind_T15_inner_class_inheritance(std::function< pybind11::module &(std::string const &namespace_) > &M)
+{
+	{ // outer file:T15.inner_class.inheritance.hpp line:10
+		pybind11::class_<outer, std::shared_ptr<outer>> cl(M(""), "outer", "binder/test/T15.inner_class.inheritance.hpp\n \n\n  Binder self-test file. Tests for bindings of classes inheriting from inner classes.");
+		cl.def( pybind11::init( [](){ return new outer(); } ) );
+
+		{ // outer::inner file:T15.inner_class.inheritance.hpp line:11
+			auto & enclosing_class = cl;
+			pybind11::class_<outer::inner, std::shared_ptr<outer::inner>> cl(enclosing_class, "inner", "");
+			cl.def( pybind11::init( [](){ return new outer::inner(); } ) );
+			cl.def_readwrite("a", &outer::inner::a);
+		}
+
+	}
+}
+
+
+// File: T15_inner_class_inheritance_1.cpp
+#include <T15.inner_class.inheritance.hpp> // outer2
+#include <sstream> // __str__
+
+#include <pybind11/pybind11.h>
+#include <functional>
+#include <string>
+
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+	#define BINDER_PYBIND11_TYPE_CASTER
+	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
+#endif
+
+void bind_T15_inner_class_inheritance_1(std::function< pybind11::module &(std::string const &namespace_) > &M)
+{
+	{ // outer2 file:T15.inner_class.inheritance.hpp line:16
+		pybind11::class_<outer2, std::shared_ptr<outer2>, outer::inner> cl(M(""), "outer2", "");
+		cl.def( pybind11::init( [](){ return new outer2(); } ) );
+		cl.def_readwrite("b", &outer2::b);
+	}
+}
+
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <functional>
+#include <string>
+
+#include <pybind11/pybind11.h>
+
+typedef std::function< pybind11::module & (std::string const &) > ModuleGetter;
+
+void bind_T15_inner_class_inheritance(std::function< pybind11::module &(std::string const &namespace_) > &M);
+void bind_T15_inner_class_inheritance_1(std::function< pybind11::module &(std::string const &namespace_) > &M);
+
+
+PYBIND11_MODULE(T15_inner_class_inheritance, root_module) {
+	root_module.doc() = "T15_inner_class_inheritance module";
+
+	std::map <std::string, pybind11::module> modules;
+	ModuleGetter M = [&](std::string const &namespace_) -> pybind11::module & {
+		auto it = modules.find(namespace_);
+		if( it == modules.end() ) throw std::runtime_error("Attempt to access pybind11::module for namespace " + namespace_ + " before it was created!!!");
+		return it->second;
+	};
+
+	modules[""] = root_module;
+
+	std::vector< std::pair<std::string, std::string> > sub_modules {
+	};
+	for(auto &p : sub_modules ) modules[p.first.size() ? p.first+"::"+p.second : p.second] = modules[p.first].def_submodule(p.second.c_str(), ("Bindings for " + p.first + "::" + p.second + " namespace").c_str() );
+
+	//pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
+
+	bind_T15_inner_class_inheritance(M);
+	bind_T15_inner_class_inheritance_1(M);
+
+}
+
+// Source list file: /home/thomas/Projects/thfe/binder/build/test//T15_inner_class_inheritance.sources
+// T15_inner_class_inheritance.cpp
+// T15_inner_class_inheritance.cpp
+// T15_inner_class_inheritance_1.cpp
+
+// Modules list file: /home/thomas/Projects/thfe/binder/build/test//T15_inner_class_inheritance.modules
+// 


### PR DESCRIPTION
Hi @lyskov,

Trying bind the code
```
struct outer {
	struct inner {
		int a;
	};
};

struct outer2 : public outer::inner {
	double b;
};
```
currently fails, giving the error `"ERROR: Could not find binder for type: "`.
The reason is that - while `outer::inner` is registered as a dependency of `outer2` - there is no `Binder` object for `outer::inner`. 
(Bindings for `outer::inner` are generated when processing struct `outer`, though.)

This pull request solves this problem by:

1. introducing an simple `Binder` class called `Dependency` which for a given type (like `outer::inner`) depends on the type (like `outer`) whose `Binder` object actually provides the bindings and
2. registers for inner classes appropriate `Dependency` objects with the `context` object.

Regards,
Thomas

  