### PR TITLE
Add useful config options for hydrogen/Qt bindings

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -84,6 +84,14 @@ Config file directives:
 
 
 
+* ``-field``, specify that particular field should be excluded from bindings.
+
+.. code-block:: bash
+
+  -field MyClass::some_field
+
+
+
 * ``include``, directive to control C++ include directives. Force Binder to either skip adding particular include into generated
   source files (``-`` prefix) or force Binder to always add some include files into each generated file. Normally Binder could
   automatically determine which C++ header files is needed in order to specify type/functions but in some cases it might be
@@ -114,6 +122,21 @@ Config file directives:
 .. code-block:: bash
 
   +include_for_namespace aaaa::bbbb <aaaa/bbbb/namespace_binding.hpp>
+
+* ``include_before``, directive to control C++ include directives to be inserted *before* ``<pybind11/pybind11.h>`` so that you have the
+  opportunity to cleanup defines introduced by other includes before the inclusion of ``<Python.h>``. This is for instance useful when dealing
+  with ``Qt`` libraries, which define ``slots``.
+
+.. code-block:: bash
+
+  +include_before <qtcleanup.hpp>
+
+
+
+.. code-block:: c++
+
+  // qtcleanup.hpp
+  #undef slots
 
 
 
@@ -157,6 +180,33 @@ Config file directives:
 .. code-block:: bash
 
   +add_on_binder_for_namespace aaaa::bbbb binder_for_namespace_aaaa_bbbb
+
+
+
+* ``+primitive``: specify that a given class should be treated as a primitive type like ``std::string``, that is, no bindings should be generated
+  for this class, but functions depending on it as parameters or return value should still be included in class bindings. The developper must then
+  provide appropriate type casters for this class.
+
+.. code-block:: bash
+
+  -class QString
+  +primitive QString
+  +include <qstring_caster.hpp>
+  +include_before <qtcleanup.hpp>
+
+
+.. code-block:: c++
+
+  #include <QtCore/QString>
+
+  class MyClass {
+
+   public:
+    ...
+    void use_some_qstring(QString param);
+    QString get_some_qstring();
+    ...
+  }
 
 
 

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -531,6 +531,10 @@ string binding_public_data_members(CXXRecordDecl const *C)
 				for(auto s = u->shadow_begin(); s != u->shadow_end(); ++s) {
 					if(UsingShadowDecl *us = dyn_cast<UsingShadowDecl>(*s) ) {
 						if( FieldDecl *f = dyn_cast<FieldDecl>( us->getTargetDecl() ) ) {
+							auto config = Config::get();
+							if ( config.is_field_skipping_requested(f->getQualifiedNameAsString())) {
+								continue;
+							}
 							if( is_bindable(f) ) c += "\tcl" + bind_data_member(f, class_qualified_name(C)) + ";\n";
 						}
 					}
@@ -541,6 +545,10 @@ string binding_public_data_members(CXXRecordDecl const *C)
 
 	for(auto d = C->decls_begin(); d != C->decls_end(); ++d) {
 		if(FieldDecl *f = dyn_cast<FieldDecl>(*d) ) {
+			auto config = Config::get();
+			if ( config.is_field_skipping_requested(f->getQualifiedNameAsString()) ) {
+				continue;
+			}
 			if( f->getAccess() == AS_public  and  is_bindable(f) ) c += "\tcl" + bind_data_member(f, class_qualified_name(C)) + ";\n";
 		}
 	}

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -54,11 +54,14 @@ void Config::read(string const &file_name)
 	string const _namespace_ {"namespace"};
 	string const _function_  {"function"};
 	string const _class_     {"class"};
+	string const _field_     {"field"};
 
 	string const _include_               {"include"};
 	string const _include_for_class_     {"include_for_class"};
 	string const _include_for_namespace_ {"include_for_namespace"};
+	string const _include_before_		 {"include_before"};
 
+	string const _primitive_			 {"primitive"};
 	string const _binder_        {"binder"};
 	string const _add_on_binder_ {"add_on_binder"};
 
@@ -120,7 +123,18 @@ void Config::read(string const &file_name)
 
 						if(bind) includes_to_add.push_back(name_without_spaces);
 						else includes_to_skip.push_back(name_without_spaces);
-
+					} else if ( token == _include_before_ ) {
+						if (bind) {
+							includes_to_add_before.push_back(name_without_spaces);
+						}
+					} else if ( token == _primitive_ ) {
+						if (bind) {
+							primitives.push_back(name_without_spaces);
+						}
+					} else if ( token == _field_ ) {
+						if (!bind) {
+							fields_to_skip.push_back(name_without_spaces);
+						}
 					} else if( token == _include_for_class_ ) {
 
 						if(bind) {
@@ -302,6 +316,23 @@ bool Config::is_class_skipping_requested(string const &class__) const
 }
 
 
+bool Config::is_field_skipping_requested(string const &field_) const
+{
+	string field {field_};
+	field.erase(std::remove(field.begin(), field.end(), ' '), field.end());
+
+	auto bind = std::find(fields_to_skip.begin(), fields_to_skip.end(), field);
+
+	if( bind != fields_to_skip.end() ) {
+		//outs() << "Skipping: " << class_ << "\n";
+		return true;
+	}
+
+	return false;
+}
+
+
+
 bool Config::is_include_skipping_requested(string const &include) const
 {
 	for(auto & i : includes_to_skip)
@@ -316,6 +347,21 @@ string Config::includes_code() const
 	string c;
 	for(auto & i: includes_to_add) c += "#include " + i + "\n";
 	return c.size() ? c+'\n' : c;
+}
+
+
+string Config::includes_before_code() const
+{
+	string c;
+	for(auto & i: includes_to_add_before) c += "#include " + i + "\n";
+	return c.size() ? c+'\n' : c;
+}
+
+bool Config::is_primitive(string const &name) const
+{
+	auto prim = std::find(primitives.begin(), primitives.end(), name);
+	if ( prim != primitives.end() ) return true;
+	return false;
 }
 
 } // namespace binder

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -59,7 +59,8 @@ public:
 
 	std::vector<string> namespaces_to_bind, classes_to_bind, functions_to_bind,
 						namespaces_to_skip, classes_to_skip, functions_to_skip,
-						includes_to_add, includes_to_skip;
+						includes_to_add, includes_to_skip,
+						includes_to_add_before, primitives, fields_to_skip;
 
 	std::map<string, string> const &binders() const { return binders_; }
 	std::map<string, string> const &add_on_binders() const { return add_on_binders_; }
@@ -96,6 +97,9 @@ public:
 	bool is_include_skipping_requested(string const &include) const;
 
 	string includes_code() const;
+	string includes_before_code() const;
+	bool is_primitive(string const &type_) const;
+	bool is_field_skipping_requested(string const &name) const;
 };
 
 

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -227,6 +227,10 @@ void Context::bind(Config const &config)
 
 		for(auto & sp : binders) {
 			Binder & b( *sp );
+			if ( config.is_primitive( b.id() ) ) {
+				flag=false;
+				continue;
+			}
 			if( !b.is_binded()  and  b.bindable() and  b.binding_requested() ) {
 				//outs() << "Binding: " << b.id() /*named_decl()->getQualifiedNameAsString()*/ << "\n";
 				b.bind(*this);
@@ -476,7 +480,7 @@ void Context::generate(Config const &config)
 
 			if( i < binders.size() ) --i;
 
-			code = generate_include_directives(includes) + fmt::format(module_header, config.includes_code()) + prefix_code + "void " + function_name + module_function_suffix + "\n{\n" + code + "}\n";
+			code = generate_include_directives(includes) + config.includes_before_code() + fmt::format(module_header, config.includes_code()) + prefix_code + "void " + function_name + module_function_suffix + "\n{\n" + code + "}\n";
 
 			if( O_single_file ) root_module_file_handle << "// File: " << file_name << '\n' << code << "\n\n";
 			else update_source_file(config.prefix, file_name, code);

--- a/source/function.cpp
+++ b/source/function.cpp
@@ -269,8 +269,14 @@ bool is_binding_requested(FunctionDecl const *F, Config const &config)
 {
 	bool bind = config.is_function_binding_requested( F->getQualifiedNameAsString() ) or  config.is_function_binding_requested( function_qualified_name(F) )  or  config.is_namespace_binding_requested( namespace_from_named_decl(F) );
 
-	for(auto & t : get_type_dependencies(F) ) bind |= binder::is_binding_requested(t, config);
-
+	for(auto & t : get_type_dependencies(F) ) {
+		bool requested = binder::is_binding_requested(t, config);
+		bool primitive = binder::is_primitive(t, config);
+		if ( primitive ) {
+			requested = false;
+		}
+		bind |= requested; // binder::is_binding_requested(t, config);
+	}
 	return bind;
 }
 
@@ -296,8 +302,18 @@ bool is_skipping_requested(FunctionDecl const *F, Config const &config)
 	}
 	//outs() << "OK\n";
 
-	for(auto & t : get_type_dependencies(F) ) skip |= is_skipping_requested(t, config);
-
+	for(auto & t : get_type_dependencies(F) ) {
+		bool dep_skip = is_skipping_requested(t, config);
+		bool primitive = is_primitive(t, config);
+		if ( primitive ) dep_skip = false;
+		skip |= dep_skip;
+	}
+	// if (skip) {
+	// 	// check if explicitly added
+	// 	if (config.is_function_binding_requested(F->getQualifiedNameAsString())) {
+	// 		skip = false;
+	// 	}
+	// }
 	return skip;
 }
 

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -660,4 +660,11 @@ bool is_banned_symbol(clang::NamedDecl const *D)
 // 	return false;
 // }
 
+bool is_primitive(const clang::QualType &qt, const Config &config) {
+	auto id = qt.getBaseTypeIdentifier();
+	if ( ! id ) return false;
+	auto name = id->getName();
+	return config.is_primitive( name.str() );
+};
+
 } // namespace binder

--- a/source/type.hpp
+++ b/source/type.hpp
@@ -68,7 +68,7 @@ bool is_banned_symbol(clang::NamedDecl const *D);
 // check if class/struct is in banned type lists
 //bool is_banned_type(clang::CXXRecordDecl const *C);
 
-
+bool is_primitive(clang::QualType const &qt, const Config &config);
 } // namespace binder
 
 #endif  // _INCLUDED_type_hpp_


### PR DESCRIPTION
Hi, congrats for your work, binder is amazing. Here is a patch adding some configuration options that I added to make bindings for [hydrogen](https://github.com/hydrogen-music/hydrogen/pull/1303)

This patch add options to the config file:
```
-field MyClass::field_y_dont_want
+include_before <qtcleanup.h>
+primitive QString
```

`+include_before` allow us to insert headers *before* `<pyind11/pybind11.h>` so we can put, eg
```c
#undef slots
```
and make `Python.h` happy again when binding something using Qt with binder/pybind11.


`-field`allow us to opt out for a field you don't want
`+primitive`allows us to actually generate methods referencing the type without actually binding it. This works provided you have proper `type_caster` template instantiation in some included header.

Let me know what you think !
Regards,
Charbel