### PR TITLE
Add handling for bits/stl_uninitialized.h

### DIFF
--- a/source/type.cpp
+++ b/source/type.cpp
@@ -209,6 +209,7 @@ void add_relevant_include_for_decl(NamedDecl const *decl, IncludeSet &includes/*
 		make_pair("<ext/concurrence.h>",      "<memory>"),
 		make_pair("<bits/ptr_traits.h>",      "<memory>"),
 		make_pair("<bits/alloc_traits.h>",    "<memory>"),
+		make_pair("<bits/stl_uninitialized.h>",    "<memory>"),
 
 		make_pair("<bits/error_constants.h>", "<system_error>"),
 


### PR DESCRIPTION
Add handling for bits/stl_uninitialized.h, which appeared in some generated sources.
According to gcc docs this header should be related to <memory>.