### PR TITLE
In terminal output, print input files we are processing

### DIFF
--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -241,6 +241,7 @@ public:
 class BinderFrontendAction : public ASTFrontendAction {
 public:
     virtual std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(CompilerInstance &ci, StringRef file) {
+        outs() << "Process input file " << file << "\n";
         return std::unique_ptr<ASTConsumer>( new BinderASTConsumer(&ci) );
     }
 };

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -13,6 +13,7 @@
 #include <config.hpp>
 
 #include <util.hpp>
+#include <binder.hpp>
 
 
 #include <llvm/Support/raw_ostream.h>
@@ -51,6 +52,7 @@ Config &Config::get()
 /// Read config setting from file
 void Config::read(string const &file_name)
 {
+        if( O_verbose ) outs() << "Read config from file " << file_name << "\n";
 	string const _namespace_ {"namespace"};
 	string const _function_  {"function"};
 	string const _class_     {"class"};

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -228,7 +228,7 @@ void Context::bind(Config const &config)
 		for(auto & sp : binders) {
 			Binder & b( *sp );
 			if( !b.is_binded()  and  b.bindable() and  b.binding_requested() ) {
-				//outs() << "Binding: " << b.id() /*named_decl()->getQualifiedNameAsString()*/ << "\n";
+                            outs() << "Binding: " << b.id() /*named_decl()->getQualifiedNameAsString()*/ << "\n";
 				b.bind(*this);
 				flag=true;
 			}

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -228,7 +228,7 @@ void Context::bind(Config const &config)
 		for(auto & sp : binders) {
 			Binder & b( *sp );
 			if( !b.is_binded()  and  b.bindable() and  b.binding_requested() ) {
-                            outs() << "Binding: " << b.id() /*named_decl()->getQualifiedNameAsString()*/ << "\n";
+                            if( O_verbose ) outs() << "Binding: " << b.id() /*named_decl()->getQualifiedNameAsString()*/ << "\n";
 				b.bind(*this);
 				flag=true;
 			}


### PR DESCRIPTION
In particular, printing the .hpp input files that are to be processed is necessary to explain repetative output like
```
Generate bindings, pass 1...
```