### PR TITLE
source: correct typos in function comments;

### DIFF
--- a/source/class.hpp
+++ b/source/class.hpp
@@ -26,7 +26,7 @@
 
 namespace binder {
 
-// generate classtemplate specialization for ClassTemplateSpecializationDecl or empty string otherwise
+// generate class template specialization for ClassTemplateSpecializationDecl or empty string otherwise
 std::string template_specialization(clang::CXXRecordDecl const *C);
 
 
@@ -34,11 +34,11 @@ std::string template_specialization(clang::CXXRecordDecl const *C);
 std::string class_name(clang::CXXRecordDecl const *C);
 
 
-// generate qualified class name that could be used in bindings code indcluding template specialization if any
+// generate qualified class name that could be used in bindings code including template specialization if any
 std::string class_qualified_name(clang::CXXRecordDecl const *C);
 
 
-// generate vector<QualType> with all types that class uses if it tempalated
+// generate vector<QualType> with all types that class uses if it is templated
 std::vector<clang::QualType> get_type_dependencies(clang::CXXRecordDecl const *C /*, bool include_members=false*/);
 
 
@@ -61,7 +61,7 @@ bool is_skipping_requested(clang::CXXRecordDecl const *C, Config const &config);
 void add_relevant_includes(clang::CXXRecordDecl const *C, IncludeSet &includes, int level);
 
 
-/// Create forward-binding for given class which consist of only class type without any member, function or constructors
+/// Create forward-binding for forward declared class (no class members given)
 std::string bind_forward_declaration(clang::CXXRecordDecl const *C, Context &);
 
 
@@ -70,7 +70,7 @@ class ClassBinder : public Binder
 public:
 	ClassBinder(clang::CXXRecordDecl const *c) : C(c) {}
 
-	/// Generate string id that uniquly identify C++ binding object. For functions this is function prototype and for classes forward declaration.
+	/// Generate string id that uniquely identify C++ binding object. For functions this is function prototype and for classes forward declaration.
 	string id() const override;
 
 	// return Clang AST NamedDecl pointer to original declaration used to create this Binder
@@ -110,7 +110,7 @@ private:
 
 	void generate_prefix_code();
 
-	// do f for each nested public class
+	// do for each nested public class
 	void for_public_nested_classes(std::function<void(clang::CXXRecordDecl const *)> const&f) const;
 
 	// generating bindings for public nested classes

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -250,7 +250,7 @@ void Context::sort_binders()
 		repeat = false;
 		binded = forward;
 		for(auto b=binders.begin(); b!=binders.end(); ++b) {
-			if( CXXRecordDecl const *C = dyn_cast<CXXRecordDecl const >( (*b)->named_decl() ) ) { // right not only querry dependency if we dealing with class
+			if( CXXRecordDecl const *C = dyn_cast<CXXRecordDecl const >( (*b)->named_decl() ) ) { // right not only query dependency if we dealing with class
 				std::vector<CXXRecordDecl const *> const dependencies = (*b)->dependencies();
 				for(auto & c : dependencies ) {
 					if( is_forward_needed(c) ) {
@@ -460,7 +460,7 @@ void Context::generate(Config const &config)
 				// 	add_to_binded( dynamic_cast<CXXRecordDecl*>( CB->named_decl() ) );
 				// }
 
-				// if( CXXRecordDecl const *C = dyn_cast<CXXRecordDecl const >( binders[i]->named_decl() ) ) { // right not only querry dependency if we dealing with class
+				// if( CXXRecordDecl const *C = dyn_cast<CXXRecordDecl const >( binders[i]->named_decl() ) ) { // right not only query dependency if we dealing with class
 				// 	std::vector<clang::CXXRecordDecl const *> const dependencies = binders[i]->dependencies();
 				// 	for(auto & c : dependencies ) {
 				// 		if( is_forward_needed(c) ) {

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -113,7 +113,7 @@ void Context::add_insertion_operator(clang::FunctionDecl const *F)
 	insertion_operators[ function_pointer_type(F) ] = F;
 }
 
-/// find gloval insertion operator for given type, return nullptr if not such operator find
+/// find global insertion operator for given type, return nullptr if not such operator find
 clang::FunctionDecl const * Context::global_insertion_operator(clang::CXXRecordDecl const *C)
 {
 	string op_pointer = "std::ostream & (*)(std::ostream &, const " + (C->isStruct() ? string("struct ") : string("class ") ) + class_qualified_name(C) + " &)";
@@ -238,7 +238,7 @@ void Context::bind(Config const &config)
 	}
 }
 
-/// sort vector of binders by dependecy so python imports could work
+/// sort vector of binders by dependency so python imports could work
 void Context::sort_binders()
 {
 	outs() << "Sorting Binders...\n";

--- a/source/context.hpp
+++ b/source/context.hpp
@@ -167,7 +167,7 @@ private:
 	/// array of all binders from translation unit
 	std::vector<BinderOP> binders;
 
-	/// types -> binder
+	/// types → binder
 	std::unordered_map<string, BinderOP> types;
 
 	/// set of items unique id's to keep track of binders being added

--- a/source/context.hpp
+++ b/source/context.hpp
@@ -85,17 +85,17 @@ public:
 	/// generate binding code for this object and all its dependencies
 	virtual void bind(Context &) = 0;
 
-	// return true if code was already generate for this object
+	/// return true if code was already generated for this object
 	bool is_binded() const;
 
-	// return binding code
+	/// return binding code
 	string & code() { return code_; }
 	string const & code() const { return code_; }
 
-	/// return true if object declared in system header
+	/// return true if object is declared in system header
 	bool is_in_system_header();
 
-	// return vector of declarations that need to be binded before this one could
+	/// return vector of declarations that need to be binded before this one could
 	virtual std::vector<clang::CXXRecordDecl const *> dependencies() const { return std::vector<clang::CXXRecordDecl const *>(); }
 
 	/// return prefix portion of bindings code
@@ -130,7 +130,7 @@ public:
 
 	void generate(Config const &config);
 
-	// find binder related to given type name and bind it
+	/// find binder related to given type name and bind it
 	void request_bindings(std::string const &type);
 
 	/// generate C++ expression for module variable for namespace_
@@ -138,7 +138,7 @@ public:
 
 	void add_insertion_operator(clang::FunctionDecl const *f);
 
-	/// find gloval insertion operator for given type, return nullptr if not such operator find
+	/// find global insertion operator for given type, otherwise return nullptr
 	clang::FunctionDecl const * global_insertion_operator(clang::CXXRecordDecl const *);
 
 	/// generate unique trace line containing `info` to insert into the code
@@ -146,34 +146,34 @@ public:
 
 private:
 
-	/// bind all objects residing in namespaces and it dependency
+	/// bind all objects residing in namespaces and their dependencies
 	void bind(Config const &config);
 
 	std::set<string> create_all_nested_namespaces();
 
-		/// check if forward declaration for CXXRecordDecl needed
+	/// check if forward declaration for CXXRecordDecl needed
 	bool is_forward_needed(clang::CXXRecordDecl const *);
 
-	/// add given class to 'aleady binded' set
+	/// add given class to 'already binded' set
 	void add_to_binded(clang::CXXRecordDecl const *);
 
-	/// sort vector of binders by dependecy so python imports could work
+	/// sort vector of binders by dependency so python imports could work
 	void sort_binders();
 
 
-	/// map of function-ptr -> Decl* for global instertion operators so we can determent for which types can bind __repr__
+	/// map of function-ptr -> Decl* for global instertion operators so we can determine for which types we can bind __repr__
 	std::map<std::string, clang::FunctionDecl const *> insertion_operators;
 
-	/// array of all binderes from translation unit
+	/// array of all binders from translation unit
 	std::vector<BinderOP> binders;
 
-	/// types → binder
+	/// types -> binder
 	std::unordered_map<string, BinderOP> types;
 
-	/// set of items unique id's to keep track of whats binders being added
+	/// set of items unique id's to keep track of binders being added
 	std::unordered_set<string> ids;
 
-	/// set of items unique id's to keep track of whats binded and not
+	/// set of items unique id's to keep track of what is binded and not
 	std::set<string> binded;
 
 	/// counter to generate unique trace lines for debug

--- a/source/function.hpp
+++ b/source/function.hpp
@@ -24,29 +24,29 @@
 namespace binder {
 
 
-// Generate function argument list separate by comma
+/// Generate function argument list separated by comma
 std::string function_arguments(clang::FunctionDecl const *record);
 
-// Generate function argument list separate by comma
-// name_arguments - if arguments should be named: a1, a2, ...
-// n - number of arguments to generate. If n > num_of_function_parameters - generate only list with num_of_function_parameters
+/// Generate function argument list separated by comma
+/// name_arguments - if arguments should be named: a1, a2, ...
+/// n - number of arguments to generate. If n > num_of_function_parameters - generate only list with num_of_function_parameters
 std::pair<std::string, std::string> function_arguments_for_lambda(clang::FunctionDecl const *record, uint n);
 
 
-// Generate function argument list with types separate by comma and with only arguments names
-// name_arguments - if arguments should be named: a1, a2, ...
+/// Generate function argument list with types separated by comma and with only arguments names
+/// name_arguments - if arguments should be named: a1, a2, ...
 std::tuple<std::string, std::string, std::string> function_arguments_for_py_overload(clang::FunctionDecl const *record);
 
 
-// generate string represetiong class name that could be used in python
+/// generate string representing class name that could be used in python
 std::string python_function_name(clang::FunctionDecl const *F);
 
 
-// Generate function pointer type string for given function. Example void (*)(int, doule)_ or  void (ClassName::*)(int, doule)_ for memeber function
+/// Generate function pointer type string for given function. Example void (*)(int, doule)_ or  void (ClassName::*)(int, doule)_ for memeber function
 std::string function_pointer_type(clang::FunctionDecl const *record);
 
 
-// generate qualified function name that could be used in bindings code indcluding template specialization if any
+/// generate qualified function name that could be used in bindings code including template specialization if any
 std::string function_qualified_name(clang::FunctionDecl const *F, bool omit_return_type=false);
 
 /// check if user requested binding for the given declaration
@@ -82,7 +82,7 @@ public:
 	/// Generate string id that uniquly identify C++ binding object. For functions this is function prototype and for classes forward declaration.
 	string id() const override;
 
-	// return Clang AST NamedDecl pointer to original declaration used to create this Binder
+	/// return Clang AST NamedDecl pointer to original declaration used to create this Binder
 	clang::NamedDecl const * named_decl() const override { return F; };
 
 	/// check if generator can create binding

--- a/source/type.hpp
+++ b/source/type.hpp
@@ -30,11 +30,11 @@ bool is_binding_requested(clang::QualType const &qt, Config const &config);
 bool is_skipping_requested(clang::QualType const &qt, Config const &config);
 
 
-// extract include path needed for declaration itself (without template dependency if any), return empty string if no include could be found
+/// extract include path needed for declaration itself (without template dependency if any), return empty string if no include could be found
 std::string relevant_include(clang::NamedDecl const *decl);
 
 
-// extract include path needed for declaration itself (without template dependency if any), do nothing if include could not be found (ie for build-in's)
+/// extract include path needed for declaration itself (without template dependency if any), do nothing if include could not be found (ie for build-in's)
 void add_relevant_include_for_decl(clang::NamedDecl const *decl, IncludeSet &includes);
 
 
@@ -42,7 +42,7 @@ void add_relevant_include_for_decl(clang::NamedDecl const *decl, IncludeSet &inc
 void add_relevant_includes(clang::QualType const &qt, /*clang::ASTContext const &context,*/ IncludeSet &includes, int level);
 
 
-// check if given QualType is bindable
+/// check if given QualType is bindable
 bool is_bindable(clang::QualType const &qt);
 
 
@@ -50,11 +50,11 @@ bool is_bindable(clang::QualType const &qt);
 void request_bindings(clang::QualType const &qt, Context &context);
 
 
-// transform give type name to standard form
+/// transform give type name to standard form
 std::string standard_name(std::string const &type);
 
 
-/// Attempt to simplify std:: name by removing unneded template arguments. Function assume that there is no 'std::' namespaces prefix at the beginning of the argument string
+/// Attempt to simplify std:: name by removing unneeded template arguments, assuming that there is no 'std::' namespaces prefix at the beginning of the argument string
 std::string simplify_std_class_name(std::string const &type);
 
 
@@ -62,10 +62,10 @@ std::string simplify_std_class_name(std::string const &type);
 bool is_python_builtin(clang::NamedDecl const *C);
 
 
-// check if class/struct/function/enum is in banned symbol lists
+/// check if class/struct/function/enum is in banned symbol lists
 bool is_banned_symbol(clang::NamedDecl const *D);
 
-// check if class/struct is in banned type lists
+/// check if class/struct is in banned type lists
 //bool is_banned_type(clang::CXXRecordDecl const *C);
 
 

--- a/source/util.hpp
+++ b/source/util.hpp
@@ -29,7 +29,7 @@ namespace binder {
 std::vector<std::string> split(std::string const &buffer, std::string const & separator="\n");
 
 
-/// Replace all occurrences of string inplace
+/// Replace all occurrences of string in-place
 void replace(std::string &r, std::string const & from, std::string const &to);
 
 /// Replace all occurrences of string and return result as new string
@@ -45,7 +45,7 @@ bool ends_with(std::string const &source, std::string const &prefix);
 std::string indent(std::string const &code, std::string const &indentation);
 
 
-/// Try to read exisitng file and if content does not match to code - write a new version. Also create nested dirs starting from prefix if nessesary.
+/// Try to read existing file. If file content does not match given code, overwrite the file with code. Also create nested dirs starting from prefix if nessesary.
 void update_source_file(std::string const &prefix, std::string const &file_name, std::string const &code);
 
 
@@ -74,16 +74,17 @@ std::string expresion_to_string(clang::Expr *e);
 std::string template_argument_to_string(clang::TemplateArgument const &);
 
 
-/// calcualte line in source file for NamedDecl
+/// calculate line in source file for NamedDecl
 std::string line_number(clang::NamedDecl const *decl);
 
-// generate string represetiong class name that could be used in python
+/// generate string represeting class name that could be used in python
 std::string mangle_type_name(std::string const &name, bool mark_template=true);
 
-// generate C++ comment line for given declartion along with file path and line number: // core::scoring::vdwaals::VDWAtom file:core/scoring/vdwaals/VDWTrie.hh line:43
+/// generate C++ comment line for given declaration along with file path and line number
+    // core::scoring::vdwaals::VDWAtom file:core/scoring/vdwaals/VDWTrie.hh line:43
 std::string generate_comment_for_declaration(clang::NamedDecl const *decl);
 
-// extract doc string (Doxygen comments) for given declaration and convert it to C++ source code string
+/// extract doc string (Doxygen comments) for given declaration and convert it to C++ code
 std::string generate_documentation_string_for_declaration(clang::Decl const*);
 
 


### PR DESCRIPTION
try to make sense of unclear comments;

uniformly use '///' for Doxygen function/class/namespace comments