### PR TITLE
spell out namespace prefixes, rather than applying 'using' to entire namespaces.

### DIFF
--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -261,7 +261,7 @@ int main(int argc, const char **argv)
 	//CommonOptionsParser op(argc, argv, BinderToolCategory);
 	if( llvm::Expected< ct::CommonOptionsParser > eop = ct::CommonOptionsParser::create(argc, argv, BinderToolCategory) ) {
 			ct::ClangTool tool(eop->getCompilations(), eop->getSourcePathList());
-		return tool.run(newFrontendActionFactory<BinderFrontendAction>().get());
+			return tool.run(ct::newFrontendActionFactory<BinderFrontendAction>().get());
 	}
 	else {
 		auto errs = eop.takeError();

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -20,11 +20,34 @@
 #include <fmt/format.h>
 
 #include <clang/AST/DeclTemplate.h>
-//#include <clang/AST/TemplateBase.h>
 
+using clang::AS_private;
+using clang::AS_protected;
+using clang::AS_public;
+using clang::CXXConstructorDecl;
+using clang::CXXDestructorDecl;
+using clang::CXXMethodDecl;
+using clang::CXXRecordDecl;
+using clang::ClassTemplateDecl;
+using clang::ClassTemplateSpecializationDecl;
+using clang::EnumDecl;
+using clang::FieldDecl;
+using clang::FinalAttr;
+using clang::FunctionDecl;
+using clang::FunctionProtoType;
+using clang::FunctionTemplateDecl;
+using clang::QualType;
+using clang::RecordType;
+using clang::TemplateArgument;
+using clang::UsingDecl;
+using clang::UsingShadowDecl;
+using clang::ValueDecl;
 
-using namespace llvm;
-using namespace clang;
+using llvm::cast;
+using llvm::dyn_cast;
+using llvm::isa;
+
+using fmt::literals::operator""_format;
 
 using std::string;
 using std::pair;
@@ -32,10 +55,6 @@ using std::tuple;
 using std::make_pair;
 using std::vector;
 using std::set;
-
-//using std::unordered_map;
-
-using namespace fmt::literals;
 
 namespace binder {
 

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -15,13 +15,12 @@
 #include <util.hpp>
 #include <binder.hpp>
 
-
 #include <llvm/Support/raw_ostream.h>
 
 #include <stdexcept>
 #include <fstream>
 
-using namespace llvm;
+using llvm::outs;
 
 using std::string;
 

--- a/source/enum.cpp
+++ b/source/enum.cpp
@@ -20,13 +20,21 @@
 
 #include <clang/AST/ASTContext.h>
 
-using namespace llvm;
-using namespace clang;
+using clang::DeclContext;
+using clang::DecompositionDecl;
+using clang::EnumDecl;
+using clang::NamedDecl;
+
+using llvm::cast;
+using llvm::dyn_cast;
+using llvm::isa;
+using llvm::SmallVector;
+
+using fmt::literals::operator""_format;
 
 using std::string;
 using std::vector;
 
-using namespace fmt::literals;
 
 namespace binder {
 
@@ -72,8 +80,8 @@ std::string getQualifiedNameAsStringLLVM5Fix( NamedDecl const *E) {
 			if ( ED->isScoped() ) {
 				OS<<*ED; OS<<"::";
 				} else continue;
-		} else { 
-			OS << *cast<NamedDecl>(DC);  
+		} else {
+			OS << *cast<NamedDecl>(DC);
 			OS<<"::";
 		}
 	}
@@ -143,7 +151,6 @@ void EnumBinder::bind(Context &context)
 	code()  = "\t" + generate_comment_for_declaration(E);
 	code() += bind_enum(module_variable_name, E) + ";\n\n";
 }
-
 
 
 } // namespace binder

--- a/source/function.cpp
+++ b/source/function.cpp
@@ -198,7 +198,7 @@ string python_function_name(FunctionDecl const *F)
 {
 	if( F->isOverloadedOperator() ) return cpp_python_operator_map.at( F->getNameAsString() );
 	else {
-		// if( auto m = llvm::dyn_cast<clang::CXXMethodDecl>(F) ) {
+		// if( auto m = dyn_cast<clang::CXXMethodDecl>(F) ) {
 		// }
 		// else{
 		// 	if( F->getTemplatedKind() == FunctionDecl::TK_MemberSpecialization  or   F->getTemplatedKind() == FunctionDecl::TK_FunctionTemplateSpecialization ) outs() << namespace_from_named_decl(F) << "::" << F->getNameAsString() << "\n";
@@ -215,7 +215,7 @@ string function_pointer_type(FunctionDecl const *F)
 {
 	string r;
 	string prefix, maybe_const;
-	if( auto m = llvm::dyn_cast<clang::CXXMethodDecl>(F) ) {
+	if( auto m = dyn_cast<clang::CXXMethodDecl>(F) ) {
 		prefix = m->isStatic() ? "" : class_qualified_name( cast<CXXRecordDecl>( F->getParent() ) ) + "::";
 	    maybe_const = m->isConst() ? " const" : "";
 	}
@@ -236,7 +236,7 @@ string function_pointer_type(FunctionDecl const *F)
 string function_qualified_name(FunctionDecl const *F, bool omit_return_type)
 {
 	string maybe_const;
-	if( auto m = llvm::dyn_cast<CXXMethodDecl>(F) ) maybe_const = m->isConst() ? " const" : "";
+	if( auto m = dyn_cast<CXXMethodDecl>(F) ) maybe_const = m->isConst() ? " const" : "";
 
 	string r = ( omit_return_type ? "" : F->getReturnType().getCanonicalType().getAsString() + " " ) +
 		       standard_name( F->getQualifiedNameAsString() + template_specialization(F) ) + "(" + function_arguments(F) + ")" + maybe_const;
@@ -297,9 +297,9 @@ bool is_skipping_requested(FunctionDecl const *F, Config const &config)
 	// calculating skipping for template classes without template specialization specified as: myclass::member_function_to_skip
 	//outs() << "Checking skipping for function: " << function_qualified_name(F, true) << "...\n";
 
-	if( CXXMethodDecl const *M = llvm::dyn_cast<CXXMethodDecl>(F) ) {
+	if( CXXMethodDecl const *M = dyn_cast<CXXMethodDecl>(F) ) {
 		CXXRecordDecl const *C = M->getParent();
-		if( llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(C) ) {
+		if( dyn_cast<clang::ClassTemplateSpecializationDecl>(C) ) {
 			//outs() << C->getQualifiedNameAsString() << "::" << F->getNameAsString() << "\n";
 			skip |= config.is_function_skipping_requested( standard_name( C->getQualifiedNameAsString() + "::" + F->getNameAsString() ) );
 		}
@@ -319,7 +319,7 @@ string bind_function(FunctionDecl const *F, uint args_to_bind, bool request_bind
 
 	string function_qualified_name = standard_name( parent ? class_qualified_name(parent) + "::" + F->getNameAsString() : F->getQualifiedNameAsString() );
 
-	CXXMethodDecl const * m = llvm::dyn_cast<CXXMethodDecl>(F);
+	CXXMethodDecl const * m = dyn_cast<CXXMethodDecl>(F);
 	string maybe_static = m and m->isStatic() ? "_static" : "";
 
 	string function, documentation;
@@ -487,7 +487,7 @@ bool is_overloadable(CXXMethodDecl const *M)
 	QualType qt = M->getReturnType().getCanonicalType();
 
 
-	if( ReferenceType const *rt = llvm::dyn_cast<ReferenceType>( qt.getTypePtr() ) ) {
+	if( ReferenceType const *rt = dyn_cast<ReferenceType>( qt.getTypePtr() ) ) {
 		if( rt->getPointeeType()->isBuiltinType() ) return false;
 
 		string r = standard_name( qt.getAsString() );

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -23,15 +23,19 @@
 #include <clang/Basic/SourceManager.h>
 #include <llvm/Support/Regex.h>
 
-
-//#include <experimental/filesystem>
 #include <cstdlib>
 #include <fstream>
 
-//using namespace llvm;
-using llvm::outs;
 
-using namespace clang;
+using clang::CXXRecordDecl;
+using clang::PointerType;
+using clang::ReferenceType;
+using clang::QualType;
+
+using llvm::cast;
+using llvm::dyn_cast;
+using llvm::isa;
+using llvm::outs;
 
 using std::string;
 using std::vector;
@@ -44,7 +48,7 @@ namespace binder {
 /// check if user requested binding for the given QualType
 bool is_binding_requested(clang::QualType const &qt, Config const &config)
 {
-	if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) return is_binding_requested(pt->getPointeeType(), config);
+	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) return is_binding_requested(pt->getPointeeType(), config);
 
 	if( ReferenceType const *rt = dyn_cast<ReferenceType>( qt.getTypePtr() ) ) return is_binding_requested(rt->getPointeeType(), config);
 
@@ -57,7 +61,7 @@ bool is_binding_requested(clang::QualType const &qt, Config const &config)
 // check if user requested skipping for the given declaration
 bool is_skipping_requested(QualType const &qt, Config const &config)
 {
-	if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) return is_skipping_requested(pt->getPointeeType(), config);
+	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) return is_skipping_requested(pt->getPointeeType(), config);
 
 	if( ReferenceType const *rt = dyn_cast<ReferenceType>( qt.getTypePtr() ) ) return is_skipping_requested(rt->getPointeeType(), config);
 
@@ -70,20 +74,20 @@ bool is_skipping_requested(QualType const &qt, Config const &config)
 bool is_function_type(QualType const &qt)
 {
 	if( auto f = dyn_cast<clang::FunctionType>( qt.getTypePtr() ) ) return true;
-	if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) return is_function_type( pt->getPointeeType() );
+	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) return is_function_type( pt->getPointeeType() );
 	if( ReferenceType const *rt = dyn_cast<ReferenceType>( qt.getTypePtr() ) ) return is_function_type( rt->getPointeeType() );
 	return false;
 }
 
 
 // extract include path needed for declaration itself (without template dependency if any), return empty string if no include could be found
-string relevant_include(NamedDecl const *decl)
+string relevant_include(clang::NamedDecl const *decl)
 {
-	ASTContext & ast_context( decl->getASTContext() );
-	SourceManager & sm( ast_context.getSourceManager() );
+	clang::ASTContext & ast_context( decl->getASTContext() );
+	clang::SourceManager & sm( ast_context.getSourceManager() );
 
-	FileID fid = sm.getFileID( decl->getLocation() );
-	SourceLocation include = sm.getIncludeLoc(fid);
+        clang::FileID fid = sm.getFileID( decl->getLocation() );
+        clang::SourceLocation include = sm.getIncludeLoc(fid);
 
 	//outs() << "SL: "; include.dump(sm); outs() << "\n";
 
@@ -106,7 +110,7 @@ string relevant_include(NamedDecl const *decl)
 
 
 // extract include path needed for declaration itself (without template dependency if any), do nothing if include could not be found (ie for build-in's)
-void add_relevant_include_for_decl(NamedDecl const *decl, IncludeSet &includes/*, std::set<clang::NamedDecl const *> &stack*/)
+void add_relevant_include_for_decl(clang::NamedDecl const *decl, IncludeSet &includes/*, std::set<clang::NamedDecl const *> &stack*/)
 {
 	static std::unordered_map<string, string> type_map;
 
@@ -285,9 +289,9 @@ void add_relevant_include_for_decl(NamedDecl const *decl, IncludeSet &includes/*
 	string name;
 
 	if( decl->isCXXClassMember() ) {
-		NamedDecl const * D = decl;
+            clang::NamedDecl const * D = decl;
 
-		if( auto m = dyn_cast<CXXMethodDecl>(decl) ) {
+            if( auto m = dyn_cast<clang::CXXMethodDecl>(decl) ) {
 			D = cast<CXXRecordDecl>( m->getParent() );
 			name = D->getQualifiedNameAsString();
 			//outs() << "CXXMethodDecl: looking for includes for type: " << name << " (was: " << decl->getQualifiedNameAsString() <<") \n";
@@ -348,10 +352,10 @@ void add_relevant_includes(QualType const &qt, /*const ASTContext &context,*/ In
 {
 	//QualType qt = qt.getDesugaredType(context);
 	//outs() << "add_relevant_includes(qt): " << qt.getAsString() << "\n";
-	if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) add_relevant_includes(pt->getPointeeType(), includes, level);
+	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) add_relevant_includes(pt->getPointeeType(), includes, level);
 	if( ReferenceType const *rt = dyn_cast<ReferenceType>( qt.getTypePtr() ) ) add_relevant_includes(rt->getPointeeType(), includes, level);
 	if( CXXRecordDecl *r = qt->getAsCXXRecordDecl() ) add_relevant_includes(r, includes, level);
-	if( EnumDecl *e = dyn_cast_or_null<EnumDecl>( qt->getAsTagDecl() ) ) add_relevant_includes(e, includes, level);
+	if( auto *e = llvm::dyn_cast_or_null<clang::EnumDecl>( qt->getAsTagDecl() ) ) add_relevant_includes(e, includes, level);
 }
 
 
@@ -362,7 +366,7 @@ bool is_bindable(QualType const &qt)
 
 	r &= !qt->isFunctionPointerType()  and  !qt->isRValueReferenceType()  and  !qt->isInstantiationDependentType()  and  !qt->isArrayType();  //and  !qt->isConstantArrayType()  and  !qt->isIncompleteArrayType()  and  !qt->isVariableArrayType()  and  !qt->isDependentSizedArrayType()
 
-	if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) {
+	if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) {
 		QualType pqt = pt->getPointeeType();
 
 		if( pqt->isPointerType() ) return false;  // refuse to bind 'value**...' types
@@ -395,13 +399,13 @@ bool is_bindable(QualType const &qt)
 		r &= is_bindable( pqt/*.getCanonicalType()*/ );
 	}
 
-	if( Type const *tp = qt/*.getCanonicalType()*/.getTypePtrOrNull() ) {
+	if( clang::Type const *tp = qt/*.getCanonicalType()*/.getTypePtrOrNull() ) {
 		if( CXXRecordDecl *rd = tp->getAsCXXRecordDecl() ) {
 			//outs() << "is_bindable qt CXXRecordDecl:" << rd->getQualifiedNameAsString() << " " << is_bindable(rd) << "\n";
 			r &= is_bindable(rd);
 		}
-		if( TagDecl *td = tp->getAsTagDecl() ) {
-			if( td->getAccess() == AS_protected  or  td->getAccess() == AS_private  ) return false;
+		if( clang::TagDecl *td = tp->getAsTagDecl() ) {
+                    if( td->getAccess() == clang::AS_protected  or  td->getAccess() == clang::AS_private  ) return false;
 		}
 	}
 
@@ -415,11 +419,11 @@ void request_bindings(clang::QualType const &qt, Context &context)
 {
 	if( /*is_bindable(qt)  and*/  !is_skipping_requested(qt, Config::get()) ) {
 		//outs() << "request_bindings(clang::QualType,...): " << qt.getAsString() << "\n";
-		if( TagDecl *td = qt->getAsTagDecl() ) {
-			if( td->isCompleteDefinition()  or  dyn_cast<ClassTemplateSpecializationDecl>(td) ) context.request_bindings( typename_from_type_decl(td) );
+            if( clang::TagDecl *td = qt->getAsTagDecl() ) {
+                if( td->isCompleteDefinition()  or  dyn_cast<clang::ClassTemplateSpecializationDecl>(td) ) context.request_bindings( typename_from_type_decl(td) );
 		}
 
-		if( clang::PointerType const *pt = dyn_cast<clang::PointerType>( qt.getTypePtr() ) ) {
+		if( PointerType const *pt = dyn_cast<PointerType>( qt.getTypePtr() ) ) {
 			request_bindings( pt->getPointeeType()/*.getCanonicalType()*/, context );
 		}
 
@@ -574,7 +578,7 @@ string simplify_std_class_name(string const &type)
 
 
 /// check if given class/struct is builtin in Python and therefor should not be binded
-bool is_python_builtin(NamedDecl const *C)
+bool is_python_builtin(clang::NamedDecl const *C)
 {
 	//outs() << "Considering: " << C->getQualifiedNameAsString() << "\n";
 	string name = standard_name( C->getQualifiedNameAsString() );


### PR DESCRIPTION
`using namespace clang|llvm` may be convenient in coding, but is painful for someone who wants to understand the inner working of Binder. For such newcomer, it is very helpful to point more explicitly to where classes and functions are defined.