### PR TITLE
New source files main.cpp, options.hpp; move IncludeSet and Binder from context.hpp to binder.hpp

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LLVM_LINK_COMPONENTS support)
 set(LLVM_USED_LIBS clangTooling clangBasic clangAST)
 
 add_clang_executable(binder
-  binder.cpp
+  main.cpp
 
   context.hpp
   context.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -27,6 +27,7 @@ add_clang_executable(binder
   function.cpp
 
   options.hpp
+  options.cpp
 
   type.hpp
   type.cpp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -8,6 +8,9 @@ set(LLVM_USED_LIBS clangTooling clangBasic clangAST)
 add_clang_executable(binder
   main.cpp
 
+  binder.hpp
+  binder.cpp
+
   context.hpp
   context.cpp
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -7,7 +7,6 @@ set(LLVM_USED_LIBS clangTooling clangBasic clangAST)
 
 add_clang_executable(binder
   binder.cpp
-  binder.hpp
 
   context.hpp
   context.cpp
@@ -23,6 +22,8 @@ add_clang_executable(binder
 
   function.hpp
   function.cpp
+
+  options.hpp
 
   type.hpp
   type.cpp

--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -10,8 +10,6 @@
 /// @brief  Main
 /// @author Sergey Lyskov
 
-#include <binder.hpp>
-
 // Declares clang::SyntaxOnlyAction.
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
@@ -31,6 +29,7 @@
 #include <context.hpp>
 #include <enum.hpp>
 #include <function.hpp>
+#include <options.hpp>
 #include <util.hpp>
 
 using namespace clang::tooling;

--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -1,0 +1,70 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+//
+// Copyright (c) 2016 Sergey Lyskov <sergey.lyskov@jhu.edu>
+//
+// All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+/// @file   binder/binder.cpp
+/// @brief  Classes IncludeSet and Binder
+/// @author Sergey Lyskov
+
+#include <binder.hpp>
+
+#include <type.hpp> // is_python_builtin
+
+#include <clang/AST/ASTContext.h>
+
+using std::string;
+using std::vector;
+
+namespace binder {
+
+// const std::string _module_variable_name_{"M"};
+
+// check if declaration is already in stack with level at lease as 'level' or lower and add it if it is not - return true if declaration was added
+bool IncludeSet::add_decl(clang::NamedDecl const *D, int level)
+{
+	if( stack_.count(D) and stack_[D] <= level ) return false;
+
+	stack_[D] = level;
+	return true;
+}
+
+// remove all includes and clear up the stack
+void IncludeSet::clear()
+{
+	includes_.clear();
+	stack_.clear();
+}
+
+/// return true if object declared in system header
+bool Binder::is_in_system_header()
+{
+	using namespace clang;
+	NamedDecl const *decl(named_decl());
+	ASTContext &ast_context(decl->getASTContext());
+	SourceManager &sm(ast_context.getSourceManager());
+
+	return FullSourceLoc(decl->getLocation(), sm).isInSystemHeader();
+}
+
+// return true if code was already generate for this object
+bool Binder::is_binded() const
+{
+	return code().size() or is_python_builtin(named_decl());
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, Binder const &b)
+{
+	clang::NamedDecl const *decl = b.named_decl();
+
+	string name = decl->getNameAsString();
+	string qualified_name = decl->getQualifiedNameAsString();
+	string path = decl->getQualifiedNameAsString().substr(0, qualified_name.size() - name.size());
+
+	return os << "B{name=" << name << ", path=" << path << "\n"; //<< ", include= " code=\n" << b("module") << "\n}
+}
+
+} // namespace binder

--- a/source/binder.hpp
+++ b/source/binder.hpp
@@ -1,0 +1,117 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+//
+// Copyright (c) 2016 Sergey Lyskov <sergey.lyskov@jhu.edu>
+//
+// All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+/// @file   binder/binder.hpp
+/// @brief  Classes IncludeSet and Binder
+/// @author Sergey Lyskov
+
+#ifndef _INCLUDED_binder_hpp_
+#define _INCLUDED_binder_hpp_
+
+#include <clang/AST/Decl.h>
+
+#include <llvm/Support/raw_ostream.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace binder {
+
+class Config;
+class Context;
+
+// structure to hold include set information and set of NamedDecl objects that was already queried for includes
+class IncludeSet
+{
+	std::vector<std::string> includes_;
+
+	std::unordered_map<clang::NamedDecl const *, int> stack_;
+
+public:
+	// add include to the set
+	void add_include(std::string const &i) { includes_.push_back(i); }
+
+	// check if declaration is already in stack with level at lease as 'level' or lower and add it if it is not - return true if declaration was added
+	bool add_decl(clang::NamedDecl const *, int level);
+
+	std::vector<std::string> const &includes() const { return includes_; }
+
+	// remove all includes and clear up the stack
+	void clear();
+};
+
+/// Bindings Generator - represent object that can generate binding info for function, class, enum or data variable
+class Binder
+{
+public:
+	typedef std::string string;
+
+	virtual ~Binder() {}
+
+	/// Generate string id that uniquely identify C++ binding object. For functions this is function prototype and for classes forward declaration.
+	virtual string id() const = 0;
+
+	// return Clang AST NamedDecl pointer to original declaration used to create this Binder
+	virtual clang::NamedDecl const *named_decl() const = 0;
+
+	/// check if generator can create binding
+	virtual bool bindable() const = 0;
+
+	bool binding_requested() const { return binding_requested_; };
+	bool skipping_requested() const { return skipping_requested_; };
+
+	/// request bindings for this generator
+	void request_bindings() { binding_requested_ = true; }
+
+	/// request skipping for this generator
+	void request_skipping() { skipping_requested_ = true; }
+
+	/// check if user supplied config requested binding for the given declaration and if so request it
+	virtual void request_bindings_and_skipping(Config const &) = 0;
+
+	/// extract include needed for this generator and add it to includes vector
+	virtual void add_relevant_includes(IncludeSet &) const = 0;
+
+	/// generate binding code for this object and all its dependencies
+	virtual void bind(Context &) = 0;
+
+	/// return true if code was already generated for this object
+	bool is_binded() const;
+
+	/// return binding code
+	string &code() { return code_; }
+	string const &code() const { return code_; }
+
+	/// return true if object is declared in system header
+	bool is_in_system_header();
+
+	/// return vector of declarations that need to be binded before this one could
+	virtual std::vector<clang::CXXRecordDecl const *> dependencies() const { return std::vector<clang::CXXRecordDecl const *>(); }
+
+	/// return prefix portion of bindings code
+	virtual string prefix_code() const { return string(); }
+
+	/// return unique strting ID for this binder
+	explicit operator std::string() const { return id(); /*named_decl()->getQualifiedNameAsString();*/ }
+
+private:
+	bool binding_requested_ = false, skipping_requested_ = false;
+
+	string code_;
+};
+
+typedef std::shared_ptr<Binder> BinderOP;
+
+typedef std::vector<BinderOP> Binders;
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, Binder const &b);
+
+} // namespace binder
+
+#endif // _INCLUDED_binder_hpp_

--- a/source/binder.hpp
+++ b/source/binder.hpp
@@ -24,7 +24,4 @@ extern llvm::cl::opt<bool> O_trace;
 extern llvm::cl::opt<bool> O_verbose;
 extern llvm::cl::opt<bool> O_flat;
 
-namespace binder {
-} // namespace binder
-
 #endif // _INCLUDED_binder_hpp_

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -10,7 +10,7 @@
 /// @brief  Binding generation for C++ struct and class objects
 /// @author Sergey Lyskov
 
-#include <binder.hpp>
+#include <options.hpp>
 #include <class.hpp>
 #include <enum.hpp>
 #include <function.hpp>

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -10,10 +10,10 @@
 /// @brief  Binding generation for C++ struct and class objects
 /// @author Sergey Lyskov
 
-#include <options.hpp>
 #include <class.hpp>
 #include <enum.hpp>
 #include <function.hpp>
+#include <options.hpp>
 #include <type.hpp>
 #include <util.hpp>
 
@@ -762,8 +762,8 @@ string binding_public_member_functions(CXXRecordDecl const *C, bool callback_str
 							if( is_bindable(m) and !is_skipping_requested(m, Config::get()) and !isa<CXXConstructorDecl>(m) and !isa<CXXDestructorDecl>(m) and !is_const_overload(m) ) {
 								// Create a new CXXRecordDecl and insert base method into inherited class so bind_function correctly resolve parent namespace for function as 'child::' instead of
 								// 'base::' CXXRecordDecl NC(*C); CXXMethodDecl *nm = CXXMethodDecl::Create(m->getParentASTContext(), &NC, m->getLocStart(), m->getNameInfo(), m->getType(),
-								// m->getTypeSourceInfo(), 										  m->getStorageClass(), m->isInlineSpecified(), m->isConstexpr() , m->getLocStart()); it looks like LLVM will delete
-								// this object when parent CXXRecordDecl is destroyed so commenting out for now... // delete nm;
+								// m->getTypeSourceInfo(), 										  m->getStorageClass(), m->isInlineSpecified(), m->isConstexpr() , m->getLocStart()); it looks like LLVM will
+								// delete this object when parent CXXRecordDecl is destroyed so commenting out for now... // delete nm;
 								c += bind_function("\tcl", m, context, C, /*always_use_lambda=*/true);
 							}
 						}

--- a/source/class.hpp
+++ b/source/class.hpp
@@ -13,7 +13,7 @@
 #ifndef _INCLUDED_class_hpp_
 #define _INCLUDED_class_hpp_
 
-#include <context.hpp>
+#include <binder.hpp>
 
 #include <clang/AST/DeclCXX.h>
 

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -12,7 +12,7 @@
 
 #include <config.hpp>
 
-#include <binder.hpp>
+#include <options.hpp>
 #include <util.hpp>
 
 

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -10,8 +10,7 @@
 /// @brief  Data structures to represent root context and modules
 /// @author Sergey Lyskov
 
-
-#include <binder.hpp>
+#include <options.hpp>
 #include <context.hpp>
 
 #include <class.hpp>

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -7,15 +7,15 @@
 // MIT license that can be found in the LICENSE file.
 
 /// @file   binder/context.cpp
-/// @brief  Data structures to represent root context and modules
+/// @brief  Class Context, to hold bindings info for whole TranslationUnit
 /// @author Sergey Lyskov
 
-#include <options.hpp>
 #include <context.hpp>
 
 #include <class.hpp>
 #include <fmt/format.h>
 #include <function.hpp>
+#include <options.hpp>
 #include <type.hpp>
 #include <util.hpp>
 
@@ -26,73 +26,121 @@
 #include <set>
 #include <sstream>
 
-// using namespace llvm;
 using llvm::errs;
 using llvm::outs;
 
 using namespace clang;
-using std::make_pair;
 using std::string;
 using std::unordered_map;
 using std::vector;
 
 using namespace fmt::literals;
-// using fmt::format;
 
 
 
 namespace binder {
 
-// const std::string _module_variable_name_{"M"};
+namespace { // functions and constants that are only used in this translation unit
 
 
-
-// check if declaration is already in stack with level at lease as 'level' or lower and add it if it is not - return true if declaration was added
-bool IncludeSet::add_decl(clang::NamedDecl const *D, int level)
+/// Generate file name where binding for given generator should be stored
+string file_name_prefix_for_binder(BinderOP &b)
 {
-	if( stack_.count(D) and stack_[D] <= level ) return false;
+	clang::NamedDecl const *decl = b->named_decl();
 
-	stack_[D] = level;
-	return true;
+	string include = binder::relevant_include(decl);
+
+	string exceptions = "_/<>.";
+	include.erase(std::remove_if(include.begin(), include.end(), [&](unsigned char c) { return not(std::isalnum(c) or std::find(exceptions.begin(), exceptions.end(), c) != exceptions.end()); }),
+				  include.end());
+
+	if( include.size() <= 2 ) {
+		include = "<unknown/unknown.hh>";
+		// outs() << "Warning: file_name_prefix_for_binder could not determent file name for decl: " + string(*b) + ", result is too short!\n";
+	} // throw std::runtime_error( "file_name_for_decl failed!!! include name for decl: " + string(*b) + " is too short!");
+	include = include.substr(1, include.size() - 2);
+
+	if( namespace_from_named_decl(decl) == "std" or begins_with(namespace_from_named_decl(decl), "std::") ) include = "std/" + (begins_with(include, "bits/") ? include.substr(5) : include);
+
+	replace(include, ".hh", "");
+	replace(include, ".hpp", "");
+	replace(include, ".h", "");
+	replace(include, ".", "_");
+	return include;
 }
 
-
-// remove all includes and clear up the stack
-void IncludeSet::clear()
+// generate code for include directives and cleanup the includes vector
+string generate_include_directives(IncludeSet const &include_set)
 {
-	includes_.clear();
-	stack_.clear();
+	string r;
+	for( auto &i : std::set<string>(include_set.includes().begin(), include_set.includes().end()) )
+		if( !Config::get().is_include_skipping_requested(i) ) r += "#include " + i + '\n';
+
+	// includes.resize(0);
+	return r;
 }
 
+const char *main_module_header = R"_(#include <map>
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
 
-/// return true if object declared in system header
-bool Binder::is_in_system_header()
-{
-	NamedDecl const *decl(named_decl());
-	ASTContext &ast_context(decl->getASTContext());
-	SourceManager &sm(ast_context.getSourceManager());
+#include <pybind11/pybind11.h>
 
-	return FullSourceLoc(decl->getLocation(), sm).isInSystemHeader();
-}
+typedef std::function< pybind11::module & (std::string const &) > ModuleGetter;
 
+{0}
 
-// return true if code was already generate for this object
-bool Binder::is_binded() const
-{
-	return code().size() or is_python_builtin(named_decl());
-}
+PYBIND11_MODULE({1}, root_module) {{
+	root_module.doc() = "{1} module";
 
+	std::map <std::string, pybind11::module> modules;
+	ModuleGetter M = [&](std::string const &namespace_) -> pybind11::module & {{
+		auto it = modules.find(namespace_);
+		if( it == modules.end() ) throw std::runtime_error("Attempt to access pybind11::module for namespace " + namespace_ + " before it was created!!!");
+		return it->second;
+	}};
 
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os, Binder const &b)
-{
-	clang::NamedDecl const *decl = b.named_decl();
+	modules[""] = root_module;
 
-	string name = decl->getNameAsString();
-	string qualified_name = decl->getQualifiedNameAsString();
-	string path = decl->getQualifiedNameAsString().substr(0, qualified_name.size() - name.size());
+	static std::vector<std::string> const reserved_python_words {{"nonlocal", "global", }};
 
-	return os << "B{name=" << name << ", path=" << path << "\n"; //<< ", include= " code=\n" << b("module") << "\n}
-}
+	auto mangle_namespace_name(
+		[](std::string const &ns) -> std::string {{
+			if ( std::find(reserved_python_words.begin(), reserved_python_words.end(), ns) == reserved_python_words.end() ) return ns;
+			else return ns+'_';
+		}}
+	);
+
+	std::vector< std::pair<std::string, std::string> > sub_modules {{
+{2}	}};
+	for(auto &p : sub_modules ) modules[p.first.size() ? p.first+"::"+p.second : p.second] = modules[p.first].def_submodule( mangle_namespace_name(p.second).c_str(), ("Bindings for " + p.first + "::" + p.second + " namespace").c_str() );
+
+	//pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
+
+{3}
+}}
+)_";
+
+const char *module_header = R"_(
+#include <functional>
+#include <pybind11/pybind11.h>
+#include <string>
+{}
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+	#define BINDER_PYBIND11_TYPE_CASTER
+	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
+#endif
+
+)_";
+
+const char *module_function_suffix = "(std::function< pybind11::module &(std::string const &namespace_) > &M)";
+
+} // namespace
 
 void Context::add(BinderOP &b)
 {
@@ -183,19 +231,6 @@ std::set<string> Context::create_all_nested_namespaces()
 	return s;
 }
 
-
-// generate code for include directives and cleanup the includes vector
-string generate_include_directives(IncludeSet const &include_set)
-{
-	string r;
-	for( auto &i : std::set<string>(include_set.includes().begin(), include_set.includes().end()) )
-		if( !Config::get().is_include_skipping_requested(i) ) r += "#include " + i + '\n';
-
-	// includes.resize(0);
-	return r;
-}
-
-
 std::string Context::module_variable_name(std::string const &namespace_)
 {
 	return "M(\"" + namespace_ + "\")";
@@ -284,96 +319,6 @@ void Context::sort_binders()
 	binded.clear();
 	outs() << "Sorting Binders... Done.\n";
 }
-
-
-/// Generate file name where binding for given generator should be stored
-string file_name_prefix_for_binder(BinderOP &b)
-{
-	clang::NamedDecl const *decl = b->named_decl();
-
-	string include = relevant_include(decl);
-
-	string exceptions = "_/<>.";
-	include.erase(std::remove_if(include.begin(), include.end(), [&](unsigned char c) { return not(std::isalnum(c) or std::find(exceptions.begin(), exceptions.end(), c) != exceptions.end()); }),
-				  include.end());
-
-	if( include.size() <= 2 ) {
-		include = "<unknown/unknown.hh>";
-		// outs() << "Warning: file_name_prefix_for_binder could not determent file name for decl: " + string(*b) + ", result is too short!\n";
-	} // throw std::runtime_error( "file_name_for_decl failed!!! include name for decl: " + string(*b) + " is too short!");
-	include = include.substr(1, include.size() - 2);
-
-	if( namespace_from_named_decl(decl) == "std" or begins_with(namespace_from_named_decl(decl), "std::") ) include = "std/" + (begins_with(include, "bits/") ? include.substr(5) : include);
-
-	replace(include, ".hh", "");
-	replace(include, ".hpp", "");
-	replace(include, ".h", "");
-	replace(include, ".", "_");
-	return include;
-}
-
-
-const char *main_module_header = R"_(#include <map>
-#include <algorithm>
-#include <functional>
-#include <memory>
-#include <stdexcept>
-#include <string>
-
-#include <pybind11/pybind11.h>
-
-typedef std::function< pybind11::module & (std::string const &) > ModuleGetter;
-
-{0}
-
-PYBIND11_MODULE({1}, root_module) {{
-	root_module.doc() = "{1} module";
-
-	std::map <std::string, pybind11::module> modules;
-	ModuleGetter M = [&](std::string const &namespace_) -> pybind11::module & {{
-		auto it = modules.find(namespace_);
-		if( it == modules.end() ) throw std::runtime_error("Attempt to access pybind11::module for namespace " + namespace_ + " before it was created!!!");
-		return it->second;
-	}};
-
-	modules[""] = root_module;
-
-	static std::vector<std::string> const reserved_python_words {{"nonlocal", "global", }};
-
-	auto mangle_namespace_name(
-		[](std::string const &ns) -> std::string {{
-			if ( std::find(reserved_python_words.begin(), reserved_python_words.end(), ns) == reserved_python_words.end() ) return ns;
-			else return ns+'_';
-		}}
-	);
-
-	std::vector< std::pair<std::string, std::string> > sub_modules {{
-{2}	}};
-	for(auto &p : sub_modules ) modules[p.first.size() ? p.first+"::"+p.second : p.second] = modules[p.first].def_submodule( mangle_namespace_name(p.second).c_str(), ("Bindings for " + p.first + "::" + p.second + " namespace").c_str() );
-
-	//pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
-
-{3}
-}}
-)_";
-
-
-const char *module_header = R"_(
-#include <functional>
-#include <pybind11/pybind11.h>
-#include <string>
-{}
-#ifndef BINDER_PYBIND11_TYPE_CASTER
-	#define BINDER_PYBIND11_TYPE_CASTER
-	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
-	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
-	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
-#endif
-
-)_";
-
-
-const char *module_function_suffix = "(std::function< pybind11::module &(std::string const &namespace_) > &M)";
 
 void Context::generate(Config const &config)
 {

--- a/source/context.hpp
+++ b/source/context.hpp
@@ -7,17 +7,15 @@
 // MIT license that can be found in the LICENSE file.
 
 /// @file   binder/context.hpp
-/// @brief  Data structures to represent root context and modules
+/// @brief  Class Context, to hold bindings info for whole TranslationUnit
 /// @author Sergey Lyskov
 
 #ifndef _INCLUDED_context_hpp_
 #define _INCLUDED_context_hpp_
 
-#include <config.hpp>
+#include <binder.hpp>
 
 #include <clang/AST/Decl.h>
-
-#include <llvm/Support/raw_ostream.h>
 
 #include <set>
 #include <string>
@@ -26,97 +24,6 @@
 #include <vector>
 
 namespace binder {
-
-class Context;
-
-// structure to hold include set information and set of NamedDecl objects that was already queried for includes
-class IncludeSet
-{
-	std::vector<std::string> includes_;
-
-	std::unordered_map<clang::NamedDecl const *, int> stack_;
-
-public:
-	// add include to the set
-	void add_include(std::string const &i) { includes_.push_back(i); }
-
-	// check if declaration is already in stack with level at lease as 'level' or lower and add it if it is not - return true if declaration was added
-	bool add_decl(clang::NamedDecl const *, int level);
-
-	std::vector<std::string> const &includes() const { return includes_; }
-
-	// remove all includes and clear up the stack
-	void clear();
-};
-
-
-/// Bindings Generator - represent object that can generate binding info for function, class, enum or data variable
-class Binder
-{
-public:
-	typedef std::string string;
-
-	virtual ~Binder() {}
-
-	/// Generate string id that uniquly identify C++ binding object. For functions this is function prototype and for classes forward declaration.
-	virtual string id() const = 0;
-
-	// return Clang AST NamedDecl pointer to original declaration used to create this Binder
-	virtual clang::NamedDecl const *named_decl() const = 0;
-
-	/// check if generator can create binding
-	virtual bool bindable() const = 0;
-
-	bool binding_requested() const { return binding_requested_; };
-	bool skipping_requested() const { return skipping_requested_; };
-
-	/// request bindings for this generator
-	void request_bindings() { binding_requested_ = true; }
-
-	/// request skipping for this generator
-	void request_skipping() { skipping_requested_ = true; }
-
-	/// check if user supplied config requested binding for the given declaration and if so request it
-	virtual void request_bindings_and_skipping(Config const &) = 0;
-
-	/// extract include needed for this generator and add it to includes vector
-	virtual void add_relevant_includes(IncludeSet &) const = 0;
-
-	/// generate binding code for this object and all its dependencies
-	virtual void bind(Context &) = 0;
-
-	/// return true if code was already generated for this object
-	bool is_binded() const;
-
-	/// return binding code
-	string &code() { return code_; }
-	string const &code() const { return code_; }
-
-	/// return true if object is declared in system header
-	bool is_in_system_header();
-
-	/// return vector of declarations that need to be binded before this one could
-	virtual std::vector<clang::CXXRecordDecl const *> dependencies() const { return std::vector<clang::CXXRecordDecl const *>(); }
-
-	/// return prefix portion of bindings code
-	virtual string prefix_code() const { return string(); }
-
-	/// return unique strting ID for this binder
-	explicit operator std::string() const { return id(); /*named_decl()->getQualifiedNameAsString();*/ }
-
-private:
-	bool binding_requested_ = false, skipping_requested_ = false;
-
-	string code_;
-};
-
-
-typedef std::shared_ptr< Binder > BinderOP;
-
-typedef std::vector<BinderOP> Binders;
-
-
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os, Binder const &b);
 
 
 /// Context - root, hold bindings info for whole TranslationUnit

--- a/source/function.hpp
+++ b/source/function.hpp
@@ -13,7 +13,7 @@
 #ifndef _INCLUDED_function_hpp_
 #define _INCLUDED_function_hpp_
 
-#include <context.hpp>
+#include <binder.hpp>
 
 #include <clang/AST/Decl.h>
 #include <clang/AST/DeclCXX.h>
@@ -23,6 +23,8 @@
 
 namespace binder {
 
+
+class Context;
 
 /// Generate function argument list separated by comma
 std::string function_arguments(clang::FunctionDecl const *record);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -26,11 +26,11 @@
 #include <llvm/Support/CommandLine.h> // Declares llvm::cl::extrahelp
 
 #include <class.hpp>
+#include <config.hpp>
 #include <context.hpp>
 #include <enum.hpp>
 #include <function.hpp>
 #include <options.hpp>
-#include <util.hpp>
 
 using namespace clang::tooling;
 using namespace llvm;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -6,7 +6,7 @@
 // All rights reserved. Use of this source code is governed by a
 // MIT license that can be found in the LICENSE file.
 
-/// @file   binder/binder.cpp
+/// @file   binder/main.cpp
 /// @brief  Main
 /// @author Sergey Lyskov
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -23,8 +23,6 @@
 #include <clang/Basic/SourceLocation.h>
 #include <clang/Frontend/CompilerInstance.h>
 
-#include <llvm/Support/CommandLine.h> // Declares llvm::cl::extrahelp
-
 #include <class.hpp>
 #include <config.hpp>
 #include <context.hpp>
@@ -35,10 +33,6 @@
 using namespace clang::tooling;
 using namespace llvm;
 
-
-// Apply a custom category to all command-line options so that they are the
-// only ones displayed.
-static llvm::cl::OptionCategory BinderToolCategory("Binder options");
 
 // CommonOptionsParser declares HelpMessage with a description of the common
 // command-line options related to the compilation database and input files.
@@ -55,34 +49,6 @@ using namespace clang;
 
 using std::string;
 
-
-cl::opt<std::string> O_root_module("root-module", cl::desc("Name of root module"), /*cl::init("example"),*/ cl::cat(BinderToolCategory));
-
-cl::opt<int> O_max_file_size("max-file-size", cl::desc("Specify maximum length of generated source files"), cl::init(1024 * 16), cl::cat(BinderToolCategory));
-
-cl::opt<std::string> O_prefix("prefix", cl::desc("Output path for all generated files. Specified path must exists."), cl::init(""), cl::cat(BinderToolCategory));
-
-cl::list<std::string> O_bind("bind", cl::desc("Namespace to bind, could be specified more then once. Specify \"\" to bind all namespaces."), cl::cat(BinderToolCategory)); // , cl::OneOrMore
-cl::list<std::string> O_skip("skip", cl::desc("Namespace to skip, could be specified more then once"), cl::cat(BinderToolCategory)); // , cl::OneOrMore
-
-cl::opt<std::string> O_config("config", cl::desc("Specify config file from which bindings setting will be read"), cl::init(""), cl::cat(BinderToolCategory));
-
-cl::opt<bool> O_annotate_includes("annotate-includes", cl::desc("Annotate each includes in generated code with type name that trigger it inclusion"), cl::init(false), cl::cat(BinderToolCategory));
-
-cl::opt<bool> O_single_file("single-file", cl::desc("Concatenate all binder output into single file with name: root-module-name + '.cpp'. Use this for a small projects and for testing."),
-							cl::init(false), cl::cat(BinderToolCategory));
-
-cl::opt<bool> O_trace("trace", cl::desc("Add tracer output for each binded object (i.e. for debugging)"), cl::init(false), cl::cat(BinderToolCategory));
-
-cl::opt<bool> O_verbose("v", cl::desc("Increase verbosity of output"), cl::init(false), cl::cat(BinderToolCategory));
-
-cl::opt<bool> O_suppress_errors("suppress-errors",
-								cl::desc("Suppres all the compilers errors. This option could be useful when you want to tell Binder to ignore non-critical errors (for example due to missing "
-										 "includes) and generate binding for part of code that Binder was able to parse"),
-								cl::init(false), cl::cat(BinderToolCategory));
-
-cl::opt<bool> O_flat("flat", cl::desc("When specified generated files into single directory. Generated files will be named as <root-module>.cpp, <root-module>_1.cpp, <root-module>_2.cpp, ... etc."),
-					 cl::init(false), cl::cat(BinderToolCategory));
 
 class ClassVisitor : public RecursiveASTVisitor<ClassVisitor>
 {

--- a/source/options.cpp
+++ b/source/options.cpp
@@ -1,0 +1,48 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+//
+// Copyright (c) 2016 Sergey Lyskov <sergey.lyskov@jhu.edu>
+//
+// All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+/// @file   binder/options.cpp
+/// @brief  Options
+/// @author Sergey Lyskov
+
+#include "options.hpp"
+#include <llvm/Support/CommandLine.h>
+
+using namespace llvm;
+
+// Apply a custom category to all command-line options so that they are the only ones displayed.
+llvm::cl::OptionCategory BinderToolCategory("Binder options");
+
+cl::opt<bool> O_annotate_includes("annotate-includes", cl::desc("Annotate each includes in generated code with type name that trigger it inclusion"), cl::init(false), cl::cat(BinderToolCategory));
+
+cl::opt<bool> O_single_file("single-file", cl::desc("Concatenate all binder output into single file with name: root-module-name + '.cpp'. Use this for a small projects and for testing."),
+							cl::init(false), cl::cat(BinderToolCategory));
+
+cl::opt<bool> O_trace("trace", cl::desc("Add tracer output for each binded object (i.e. for debugging)"), cl::init(false), cl::cat(BinderToolCategory));
+
+cl::opt<bool> O_verbose("v", cl::desc("Increase verbosity of output"), cl::init(false), cl::cat(BinderToolCategory));
+
+cl::opt<bool> O_flat("flat", cl::desc("When specified generated files into single directory. Generated files will be named as <root-module>.cpp, <root-module>_1.cpp, <root-module>_2.cpp, ... etc."),
+					 cl::init(false), cl::cat(BinderToolCategory));
+
+
+cl::opt<std::string> O_root_module("root-module", cl::desc("Name of root module"), /*cl::init("example"),*/ cl::cat(BinderToolCategory));
+
+cl::opt<int> O_max_file_size("max-file-size", cl::desc("Specify maximum length of generated source files"), cl::init(1024 * 16), cl::cat(BinderToolCategory));
+
+cl::opt<std::string> O_prefix("prefix", cl::desc("Output path for all generated files. Specified path must exists."), cl::init(""), cl::cat(BinderToolCategory));
+
+cl::list<std::string> O_bind("bind", cl::desc("Namespace to bind, could be specified more then once. Specify \"\" to bind all namespaces."), cl::cat(BinderToolCategory)); // , cl::OneOrMore
+cl::list<std::string> O_skip("skip", cl::desc("Namespace to skip, could be specified more then once"), cl::cat(BinderToolCategory)); // , cl::OneOrMore
+
+cl::opt<std::string> O_config("config", cl::desc("Specify config file from which bindings setting will be read"), cl::init(""), cl::cat(BinderToolCategory));
+
+cl::opt<bool> O_suppress_errors("suppress-errors",
+								cl::desc("Suppres all the compilers errors. This option could be useful when you want to tell Binder to ignore non-critical errors (for example due to missing "
+										 "includes) and generate binding for part of code that Binder was able to parse"),
+								cl::init(false), cl::cat(BinderToolCategory));

--- a/source/options.hpp
+++ b/source/options.hpp
@@ -17,10 +17,20 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/CommandLine.h"
 
+extern llvm::cl::OptionCategory BinderToolCategory;
+
 extern llvm::cl::opt<bool> O_annotate_includes;
 extern llvm::cl::opt<bool> O_single_file;
 extern llvm::cl::opt<bool> O_trace;
 extern llvm::cl::opt<bool> O_verbose;
 extern llvm::cl::opt<bool> O_flat;
+
+extern llvm::cl::opt<std::string> O_root_module;
+extern llvm::cl::opt<int> O_max_file_size;
+extern llvm::cl::opt<std::string> O_prefix;
+extern llvm::cl::list<std::string> O_bind;
+extern llvm::cl::list<std::string> O_skip;
+extern llvm::cl::opt<std::string> O_config;
+extern llvm::cl::opt<bool> O_suppress_errors;
 
 #endif // _INCLUDED_options_hpp_

--- a/source/options.hpp
+++ b/source/options.hpp
@@ -6,13 +6,12 @@
 // All rights reserved. Use of this source code is governed by a
 // MIT license that can be found in the LICENSE file.
 
-/// @file   binder/binder.hpp
+/// @file   binder/options.hpp
 /// @brief  Options
 /// @author Sergey Lyskov
 
-
-#ifndef _INCLUDED_binder_hpp_
-#define _INCLUDED_binder_hpp_
+#ifndef _INCLUDED_options_hpp_
+#define _INCLUDED_options_hpp_
 
 
 #include "llvm/Config/llvm-config.h"
@@ -24,4 +23,4 @@ extern llvm::cl::opt<bool> O_trace;
 extern llvm::cl::opt<bool> O_verbose;
 extern llvm::cl::opt<bool> O_flat;
 
-#endif // _INCLUDED_binder_hpp_
+#endif // _INCLUDED_options_hpp_

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -13,7 +13,7 @@
 
 #include <type.hpp>
 
-#include <binder.hpp>
+#include <options.hpp>
 #include <class.hpp>
 #include <enum.hpp>
 #include <util.hpp>

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -13,9 +13,9 @@
 
 #include <type.hpp>
 
-#include <options.hpp>
 #include <class.hpp>
 #include <enum.hpp>
+#include <options.hpp>
 #include <util.hpp>
 
 #include <clang/AST/ASTContext.h>

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -12,9 +12,9 @@
 
 #include <util.hpp>
 
-#include <options.hpp>
 #include <class.hpp>
 #include <enum.hpp>
+#include <options.hpp>
 #include <type.hpp>
 
 #include <clang/AST/ASTContext.h>

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -12,7 +12,7 @@
 
 #include <util.hpp>
 
-#include <binder.hpp>
+#include <options.hpp>
 #include <class.hpp>
 #include <enum.hpp>
 #include <type.hpp>


### PR DESCRIPTION
As proposed in https://github.com/RosettaCommons/binder/discussions/200.

This PR depends on the previous one, https://github.com/RosettaCommons/binder/pull/203; i.e. it is meant to be rebased on master after merger of #203.