### PR TITLE
Add custom shared pointer option

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -186,6 +186,7 @@ Config file directives:
 * ``default_call_guard``, optionally specify a call guard applied to all function definitions. See `pybind11 documentation <http://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard>`_. Default None.
 
 
+* ``+custom_shared``: specify a custom shared pointer class that Binder should use instead of std::shared_ptr.
 
 
 

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -868,21 +868,14 @@ string bind_forward_declaration(CXXRecordDecl const *C, Context &context)
 
 	string const include = relevant_include(C);
 
-	string shared_ptr = "std::shared_ptr";
-	bool use_custom_shared = Config::get().use_custom_shared();
-	if( use_custom_shared )
-		shared_ptr = Config::get().custom_shared();
-
+	string holder_type = Config::get().holder_type();
 
 	string c = "\t// Forward declaration for: " + qualified_name + " file:" + (include.size() ? include.substr(1, include.size() - 2) : "") + " line:" + line_number(C) + "\n";
 
-	string maybe_holder_type = ", {}<{}>"_format(shared_ptr, qualified_name);
+	string maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name);
 	//Check if the type is a custom shared pointer:
-	if( use_custom_shared && qualified_name.rfind(shared_ptr, 0) == 0 ) {
-		maybe_holder_type = "";
-	}
-	else if( is_inherited_from_enable_shared_from_this(C) ) {
-		maybe_holder_type = ", {}<{}>"_format(shared_ptr, qualified_name);
+	if( is_inherited_from_enable_shared_from_this(C) ) {
+		maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name);
 	}
 	else if( CXXDestructorDecl *d = C->getDestructor() ) {
 		if( d->getAccess() != AS_public ) maybe_holder_type = ", " + qualified_name + '*';
@@ -1184,19 +1177,12 @@ void ClassBinder::bind(Context &context)
 	string const trampoline_name = callback_structure_constructible ? callback_structure_name(C) : "";
 	string const binding_qualified_name = callback_structure_constructible ? callback_structure_name(C) : qualified_name;
 
-	string shared_ptr = "std::shared_ptr";
-	bool use_custom_shared = Config::get().use_custom_shared();
-	if( use_custom_shared )
-		shared_ptr = Config::get().custom_shared();
+	string holder_type = Config::get().holder_type();
 
+	string maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name);
 
-	string maybe_holder_type = ", {}<{}>"_format(shared_ptr, qualified_name);
-	//Check if the type is a custom shared pointer:
-	if( use_custom_shared && qualified_name.rfind(shared_ptr, 0) == 0 ) {
-		maybe_holder_type = "";
-	}
-	else if( is_inherited_from_enable_shared_from_this(C) ) {
-		maybe_holder_type = ", {}<{}>"_format(shared_ptr, qualified_name);
+	if( is_inherited_from_enable_shared_from_this(C) ) {
+		maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name);
 	}
 	else if( CXXDestructorDecl *d = C->getDestructor() ) {
 		if( d->getAccess() != AS_public ) maybe_holder_type = ", " + qualified_name + '*';

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -868,25 +868,24 @@ string bind_forward_declaration(CXXRecordDecl const *C, Context &context)
 
 	string const include = relevant_include(C);
 
+	string shared_ptr = "std::shared_ptr";
 	bool use_custom_shared = Config::get().use_custom_shared();
-	string const custom_shared = Config::get().custom_shared();
+	if( use_custom_shared )
+		shared_ptr = Config::get().custom_shared();
 
-	// Do not use custom_shared pointer if std:: class
-	if( qualified_name.rfind("std::", 0) == 0 ) use_custom_shared = false;
 
 	string c = "\t// Forward declaration for: " + qualified_name + " file:" + (include.size() ? include.substr(1, include.size() - 2) : "") + " line:" + line_number(C) + "\n";
 
-	string maybe_holder_type = ", std::shared_ptr<{}>"_format(qualified_name);
-	if( use_custom_shared ) {
-		//Check if the type is a custom shared pointer:
-		if( qualified_name.rfind(custom_shared, 0) == 0 ) maybe_holder_type = "";
-		else maybe_holder_type = ", {}<{}>"_format(custom_shared, qualified_name);
+	string maybe_holder_type = ", {}<{}>"_format(shared_ptr, qualified_name);
+	//Check if the type is a custom shared pointer:
+	if( use_custom_shared && qualified_name.rfind(shared_ptr, 0) == 0 ) {
+		maybe_holder_type = "";
 	}
-	else {
-		if( is_inherited_from_enable_shared_from_this(C) ) maybe_holder_type = ", std::shared_ptr<{}>"_format(qualified_name);
-		else if( CXXDestructorDecl *d = C->getDestructor() ) {
-			if( d->getAccess() != AS_public ) maybe_holder_type = ", " + qualified_name + '*';
-		}
+	else if( is_inherited_from_enable_shared_from_this(C) ) {
+		maybe_holder_type = ", {}<{}>"_format(shared_ptr, qualified_name);
+	}
+	else if( CXXDestructorDecl *d = C->getDestructor() ) {
+		if( d->getAccess() != AS_public ) maybe_holder_type = ", " + qualified_name + '*';
 	}
 
 	c += '\t' + R"(pybind11::class_<{}{}>({}, "{}");)"_format(qualified_name, maybe_holder_type, module_variable_name, python_class_name(C)) + "\n\n";
@@ -1185,23 +1184,22 @@ void ClassBinder::bind(Context &context)
 	string const trampoline_name = callback_structure_constructible ? callback_structure_name(C) : "";
 	string const binding_qualified_name = callback_structure_constructible ? callback_structure_name(C) : qualified_name;
 
+	string shared_ptr = "std::shared_ptr";
 	bool use_custom_shared = Config::get().use_custom_shared();
-	string const custom_shared = Config::get().custom_shared();
+	if( use_custom_shared )
+		shared_ptr = Config::get().custom_shared();
 
-	// Do not use custom_shared pointer if std:: class
-	if( qualified_name.rfind("std::", 0) == 0 ) use_custom_shared = false;
 
-	string maybe_holder_type = ", std::shared_ptr<{}>"_format(qualified_name); // for now enable std::shared_ptr by default
-	if( use_custom_shared ) {
-		//Check if the type is a custom shared pointer:
-		if( qualified_name.rfind(custom_shared, 0) == 0 ) maybe_holder_type = "";
-		else maybe_holder_type = ", {}<{}>"_format(custom_shared, qualified_name);
+	string maybe_holder_type = ", {}<{}>"_format(shared_ptr, qualified_name);
+	//Check if the type is a custom shared pointer:
+	if( use_custom_shared && qualified_name.rfind(shared_ptr, 0) == 0 ) {
+		maybe_holder_type = "";
 	}
-	else {
-		if( is_inherited_from_enable_shared_from_this(C) ) maybe_holder_type = ", std::shared_ptr<{}>"_format(qualified_name);
-		else if( CXXDestructorDecl *d = C->getDestructor() ) {
-			if( d->getAccess() != AS_public ) maybe_holder_type = ", " + qualified_name + '*';
-		}
+	else if( is_inherited_from_enable_shared_from_this(C) ) {
+		maybe_holder_type = ", {}<{}>"_format(shared_ptr, qualified_name);
+	}
+	else if( CXXDestructorDecl *d = C->getDestructor() ) {
+		if( d->getAccess() != AS_public ) maybe_holder_type = ", " + qualified_name + '*';
 	}
 	string maybe_trampoline = callback_structure_constructible ? ", " + binding_qualified_name : "";
 

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -174,7 +174,7 @@ void Config::read(string const &file_name)
 				add_on_binder_for_namespaces_[binder_function.first] = binder_function.second;
 			}
 		}
-		else if( token == _custom_shared_ ) custom_shared_ = name_without_spaces;
+		else if( token == _custom_shared_ ) holder_type_ = name_without_spaces;
 
 		else if( token == _default_static_pointer_return_value_policy_ ) default_static_pointer_return_value_policy_ = name_without_spaces;
 		else if( token == _default_static_lvalue_reference_return_value_policy_ ) default_static_lvalue_reference_return_value_policy_ = name_without_spaces;

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -67,6 +67,8 @@ void Config::read(string const &file_name)
 	string const _binder_for_namespace_{"binder_for_namespace"};
 	string const _add_on_binder_for_namespace_{"add_on_binder_for_namespace"};
 
+	string const _custom_shared_{"custom_shared"};
+
 	string const _default_static_pointer_return_value_policy_{"default_static_pointer_return_value_policy"};
 	string const _default_static_lvalue_reference_return_value_policy_{"default_static_lvalue_reference_return_value_policy"};
 	string const _default_static_rvalue_reference_return_value_policy_{"default_static_rvalue_reference_return_value_policy"};
@@ -172,6 +174,7 @@ void Config::read(string const &file_name)
 				add_on_binder_for_namespaces_[binder_function.first] = binder_function.second;
 			}
 		}
+		else if( token == _custom_shared_ ) custom_shared_ = name_without_spaces;
 
 		else if( token == _default_static_pointer_return_value_policy_ ) default_static_pointer_return_value_policy_ = name_without_spaces;
 		else if( token == _default_static_lvalue_reference_return_value_policy_ ) default_static_lvalue_reference_return_value_policy_ = name_without_spaces;

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -50,7 +50,7 @@ private:
 	string default_member_lvalue_reference_return_value_policy_ = "pybind11::return_value_policy::automatic";
 	string default_member_rvalue_reference_return_value_policy_ = "pybind11::return_value_policy::automatic";
 	string default_call_guard_ = "";
-	string custom_shared_ = "";
+	string holder_type_ = "std::shared_ptr";
 
 public:
 	static Config &get();
@@ -80,8 +80,7 @@ public:
 	string const &default_member_rvalue_reference_return_value_policy() { return default_member_rvalue_reference_return_value_policy_; }
 	string const &default_call_guard() { return default_call_guard_; }
 
-	string const &custom_shared() const { return custom_shared_; }
-	bool use_custom_shared() const { return !custom_shared_.empty(); }
+	string const &holder_type() const { return holder_type_; }
 
 	string prefix;
 

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -50,6 +50,7 @@ private:
 	string default_member_lvalue_reference_return_value_policy_ = "pybind11::return_value_policy::automatic";
 	string default_member_rvalue_reference_return_value_policy_ = "pybind11::return_value_policy::automatic";
 	string default_call_guard_ = "";
+	string custom_shared_ = "";
 
 public:
 	static Config &get();
@@ -78,6 +79,9 @@ public:
 	string const &default_member_lvalue_reference_return_value_policy() { return default_member_lvalue_reference_return_value_policy_; }
 	string const &default_member_rvalue_reference_return_value_policy() { return default_member_rvalue_reference_return_value_policy_; }
 	string const &default_call_guard() { return default_call_guard_; }
+
+	string const &custom_shared() const { return custom_shared_; }
+	bool use_custom_shared() const { return !custom_shared_.empty(); }
 
 	string prefix;
 

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -429,15 +429,10 @@ void Context::generate(Config const &config)
 
 		if( i < binders.size() ) --i;
 
-		string const custom_shared = Config::get().custom_shared();
-		bool use_custom_shared = Config::get().use_custom_shared();
+		string const holder_type = Config::get().holder_type();
 
-		string shared_declare = "PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)";
-		string shared_make_opaque = "PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)";
-		if( use_custom_shared ) {
-			shared_declare = "PYBIND11_DECLARE_HOLDER_TYPE(T, "+custom_shared+"<T>)";
-			shared_make_opaque = "PYBIND11_MAKE_OPAQUE("+custom_shared+"<void>)";
-		}
+		string shared_declare = "PYBIND11_DECLARE_HOLDER_TYPE(T, "+holder_type+"<T>)";
+		string shared_make_opaque = "PYBIND11_MAKE_OPAQUE("+holder_type+"<void>)";
 
 		code = generate_include_directives(includes) + fmt::format(module_header, config.includes_code(), shared_declare, shared_make_opaque) + prefix_code + "void " + function_name + module_function_suffix + "\n{\n" + code + "}\n";
 

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -131,6 +131,7 @@ const char *module_header = R"_(
 {}
 #ifndef BINDER_PYBIND11_TYPE_CASTER
 	#define BINDER_PYBIND11_TYPE_CASTER
+	{}
 	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
 	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
 	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
@@ -429,7 +430,14 @@ void Context::generate(Config const &config)
 
 		if( i < binders.size() ) --i;
 
-		code = generate_include_directives(includes) + fmt::format(module_header, config.includes_code()) + prefix_code + "void " + function_name + module_function_suffix + "\n{\n" + code + "}\n";
+		string const custom_shared = Config::get().custom_shared();
+		bool use_custom_shared = Config::get().use_custom_shared();
+
+		string custom_shared_declare = "";
+		if( use_custom_shared )
+			custom_shared_declare = "PYBIND11_DECLARE_HOLDER_TYPE(T, "+custom_shared+"<T>)";
+
+		code = generate_include_directives(includes) + fmt::format(module_header, config.includes_code(), custom_shared_declare) + prefix_code + "void " + function_name + module_function_suffix + "\n{\n" + code + "}\n";
 
 		if( O_single_file ) root_module_file_handle << "// File: " << file_name << '\n' << code << "\n\n";
 		else update_source_file(config.prefix, file_name, code);

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -659,7 +659,7 @@ bool is_python_builtin(NamedDecl const *C)
 
 		"std::allocator", "std::__allocator_destructor",
 
-		"std::shared_ptr", "std::enable_shared_from_this", "std::__shared_ptr", // "std::weak_ptr",  "std::__weak_ptr"
+		Config::get().holder_type(), "std::shared_ptr", "std::enable_shared_from_this", "std::__shared_ptr", // "std::weak_ptr",  "std::__weak_ptr"
 		"std::unique_ptr",
 		//"std::__1::shared_ptr", "std::__1::weak_ptr", "std::__1::allocator",
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,6 +105,7 @@ set( binder_tests
          T42.stl.names.multimap
          T42.stl.names.multiset
          T50.namespace_binder
+         T60.custom_shared
          )
 if (pybind11_VERSION VERSION_LESS 2.5.99)
  message(STATUS "pybind11 version ${pybind11_VERSION} is less than 2.5.99. Some tests will be disabled." )

--- a/test/T60.custom_shared.config
+++ b/test/T60.custom_shared.config
@@ -1,0 +1,1 @@
++custom_shared my_shared_ptr

--- a/test/T60.custom_shared.hpp
+++ b/test/T60.custom_shared.hpp
@@ -1,0 +1,43 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+//
+// Copyright (c) 2016 Sergey Lyskov <sergey.lyskov@jhu.edu>
+//
+// All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+/// @file   binder/test/T01.enum.hpp
+/// @brief  Binder self-test file. Bindings of enum's functionality.
+/// @author Sergey Lyskov
+
+#ifndef _INCLUDED_T60_hpp_
+#define _INCLUDED_T60_hpp_
+
+#include <memory>
+
+template<typename T>
+using my_shared_ptr = std::shared_ptr<T>;
+
+enum E1 { E1_V0, E1_V1 };
+
+enum struct E2_struct { V0, V1 };
+enum class E3_class { V0, V1 };
+
+
+class A
+{
+public:
+	enum AE1 { AE1_V0, AE1_V1 };
+	enum struct AE2_struct { AE3_V0, AE3_V1 };
+	enum class AE3_class { AE2_V0, AE2_V1 };
+
+protected:
+	enum AE3_not_binded { AE3_V0_not_binded, AE3_V1_not_binded };
+	enum class AE4_not_binded { AE4_V0_not_binded, AE4_V1_not_binded };
+
+private:
+	enum AE5_not_binded { AE5_V0_not_binded, AE5_V1_not_binded };
+	enum class AE6_not_binded { AE6_V0_not_binded, AE6_V1_not_binded };
+};
+
+#endif // _INCLUDED_T01_enum_hpp_

--- a/test/T60.custom_shared.ref
+++ b/test/T60.custom_shared.ref
@@ -1,0 +1,118 @@
+// File: T60_custom_shared.cpp
+#include <T60.custom_shared.hpp> // A
+#include <T60.custom_shared.hpp> // E1
+#include <T60.custom_shared.hpp> // E2_struct
+#include <T60.custom_shared.hpp> // E3_class
+#include <sstream> // __str__
+
+#include <functional>
+#include <pybind11/pybind11.h>
+#include <string>
+
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+	#define BINDER_PYBIND11_TYPE_CASTER
+	PYBIND11_DECLARE_HOLDER_TYPE(T, my_shared_ptr<T>)
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+	PYBIND11_MAKE_OPAQUE(my_shared_ptr<void>)
+#endif
+
+void bind_T60_custom_shared(std::function< pybind11::module &(std::string const &namespace_) > &M)
+{
+	// E1 file:T60.custom_shared.hpp line:21
+	pybind11::enum_<E1>(M(""), "E1", pybind11::arithmetic(), "")
+		.value("E1_V0", E1_V0)
+		.value("E1_V1", E1_V1)
+		.export_values();
+
+;
+
+	// E2_struct file:T60.custom_shared.hpp line:23
+	pybind11::enum_<E2_struct>(M(""), "E2_struct", "")
+		.value("V0", E2_struct::V0)
+		.value("V1", E2_struct::V1)
+		.export_values();
+
+;
+
+	// E3_class file:T60.custom_shared.hpp line:24
+	pybind11::enum_<E3_class>(M(""), "E3_class", "")
+		.value("V0", E3_class::V0)
+		.value("V1", E3_class::V1);
+
+;
+
+	{ // A file:T60.custom_shared.hpp line:27
+		pybind11::class_<A, my_shared_ptr<A>> cl(M(""), "A", "");
+		cl.def( pybind11::init( [](){ return new A(); } ) );
+
+		pybind11::enum_<A::AE1>(cl, "AE1", pybind11::arithmetic(), "")
+			.value("AE1_V0", A::AE1_V0)
+			.value("AE1_V1", A::AE1_V1)
+			.export_values();
+
+
+		pybind11::enum_<A::AE2_struct>(cl, "AE2_struct", "")
+			.value("AE3_V0", A::AE2_struct::AE3_V0)
+			.value("AE3_V1", A::AE2_struct::AE3_V1)
+			.export_values();
+
+
+		pybind11::enum_<A::AE3_class>(cl, "AE3_class", "")
+			.value("AE2_V0", A::AE3_class::AE2_V0)
+			.value("AE2_V1", A::AE3_class::AE2_V1);
+
+	}
+}
+
+
+#include <map>
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <pybind11/pybind11.h>
+
+typedef std::function< pybind11::module & (std::string const &) > ModuleGetter;
+
+void bind_T60_custom_shared(std::function< pybind11::module &(std::string const &namespace_) > &M);
+
+
+PYBIND11_MODULE(T60_custom_shared, root_module) {
+	root_module.doc() = "T60_custom_shared module";
+
+	std::map <std::string, pybind11::module> modules;
+	ModuleGetter M = [&](std::string const &namespace_) -> pybind11::module & {
+		auto it = modules.find(namespace_);
+		if( it == modules.end() ) throw std::runtime_error("Attempt to access pybind11::module for namespace " + namespace_ + " before it was created!!!");
+		return it->second;
+	};
+
+	modules[""] = root_module;
+
+	static std::vector<std::string> const reserved_python_words {"nonlocal", "global", };
+
+	auto mangle_namespace_name(
+		[](std::string const &ns) -> std::string {
+			if ( std::find(reserved_python_words.begin(), reserved_python_words.end(), ns) == reserved_python_words.end() ) return ns;
+			else return ns+'_';
+		}
+	);
+
+	std::vector< std::pair<std::string, std::string> > sub_modules {
+	};
+	for(auto &p : sub_modules ) modules[p.first.size() ? p.first+"::"+p.second : p.second] = modules[p.first].def_submodule( mangle_namespace_name(p.second).c_str(), ("Bindings for " + p.first + "::" + p.second + " namespace").c_str() );
+
+	//pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
+
+	bind_T60_custom_shared(M);
+
+}
+
+// Source list file: TEST/T60_custom_shared.sources
+// T60_custom_shared.cpp
+// T60_custom_shared.cpp
+
+// Modules list file: TEST/T60_custom_shared.modules
+// 


### PR DESCRIPTION
This PR is associated to one of the questions of #214.

The PR adds an option to specify a custom shared pointer class.
The header files can not be included into binder source code as it is unknown at compilation time.
Therefore, the proposed code relies on some string logic to avoid to have a custom shared pointer of a custom shared pointer.
The header(s) associated to the shared pointer should be specified with the `+include` option.
The proposed implementation avoids to create custom shared pointer of std classes.
Finally, the proposed implementation only supports to specify one custom shared pointer class.

Please @lyskov, let me know any comments/modifications that you would like to see in this PR.