### PR TITLE
STL flag to enable STL bindings

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -40,11 +40,13 @@ files. Typically the following files will be generated: ``<root-module>.cpp``, `
 ``--suppress-errors`` if the generated bindings codes are correct but there are some fatal errors from clang and you want to get rid of them. This situation can happen when you would like to generate binding codes for a small part of a huge project and the you cannot include all the required header files with ``-I`` to the command.
 
 
+``--include-pybind11-stl`` "if specified bindings for STL classes in ``<pybind11/stl.h>`` will be used instead of generating custom STL bindings. Note, STL bindings may be overkill and have potential preformance implications if data does not need to be copied between ``C++`` and ``python``. For more information, see `pybind11 documentation <https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html>`_.
+
+
 ``--annotate-includes`` [debug] if specified Binder will comment each include with type name which trigger it inclusion.
 
 
 ``--trace`` [debug] if specified instruct Binder to add extra debug output before binding each type. This might be useful when debugging generated code that produce seg-faults during python import.
-
 
 
 Config file options
@@ -198,7 +200,7 @@ Config file directives:
 * ``default_member_rvalue_reference_return_value_policy``, specify return value policy for member functions returning r-value reference. Default
   is `pybind11::return_value_policy::automatic`.
 
-* ``default_call_guard``, optionally specify a call guard applied to all function definitions. See `pybind11 documentation <http://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard>`_. Default None.
+* ``default_call_guard``, optionally specify a call guard applied to all function definitions. See `pybind11 documentation <https://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard>`_. Default None.
 
 
 

--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -81,7 +81,7 @@ Config file directives:
 * ``python_builtin``, specify if particular class/struct should be considered a python builtin and assume existing bindings for it already exist.
   The purpose of this directive is to allow developer to allow developers to toggle if bindings for types like ``std::optional`` or ``pybind11::dict`` should be
   generated, or if binder should assume such bindings already exist somewhere else. Alternatively, a developer could declare a type as not-builtin if they
-  would prefer to force binder to generate bindings for it. Note that ``-python_builtin ab`c` always overrides ``+python_builtin abc``.
+  would prefer to force binder to generate bindings for it. Note that removing a builtin (``-python_builtin abc``) always overrides everything else (such as adding a builtin via ``+python_builtin abc``).
 
 .. code-block:: bash
 

--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -40,7 +40,7 @@ files. Typically the following files will be generated: ``<root-module>.cpp``, `
 ``--suppress-errors`` if the generated bindings codes are correct but there are some fatal errors from clang and you want to get rid of them. This situation can happen when you would like to generate binding codes for a small part of a huge project and the you cannot include all the required header files with ``-I`` to the command.
 
 
-``--include-pybind11-stl`` "if specified bindings for STL classes in ``<pybind11/stl.h>`` will be used instead of generating custom STL bindings. Note, STL bindings may be overkill and have potential preformance implications if data does not need to be copied between ``C++`` and ``python``. For more information, see `pybind11 documentation <https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html>`_.
+``--include-pybind11-stl`` "if specified bindings for STL classes in ``<pybind11/stl.h>`` will be used instead of generating custom STL bindings. Note, STL bindings may be overkill and have potential preformance implications if data does not need to be copied between ``C++`` and ``python``. For more information, see `pybind11 STL documentation <https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html>`_.
 
 
 ``--annotate-includes`` [debug] if specified Binder will comment each include with type name which trigger it inclusion.

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -18,6 +18,7 @@
 
 #include <llvm/Support/raw_ostream.h>
 
+#include <sstream>
 #include <fstream>
 #include <stdexcept>
 
@@ -357,9 +358,11 @@ bool Config::is_include_skipping_requested(string const &include) const
 
 string Config::includes_code() const
 {
-	string c;
-	for( auto &i : includes_to_add ) c += "#include " + i + "\n";
-	return c.size() ? c + '\n' : c;
+	std::ostringstream s;
+	for( auto &i : includes_to_add ) s << "#include " << i << "\n";
+	if (O_include_pybind11_stl) s << "#include <pybind11/stl.h>\n";
+	if (s.tellp() != std::streampos(0)) s << '\n';
+	return s.str();
 }
 
 } // namespace binder

--- a/source/options.cpp
+++ b/source/options.cpp
@@ -30,6 +30,9 @@ cl::opt<bool> O_verbose("v", cl::desc("Increase verbosity of output"), cl::init(
 cl::opt<bool> O_flat("flat", cl::desc("When specified generated files into single directory. Generated files will be named as <root-module>.cpp, <root-module>_1.cpp, <root-module>_2.cpp, ... etc."),
 					 cl::init(false), cl::cat(BinderToolCategory));
 
+cl::opt<bool> O_stl("stl", cl::desc("When specified bindings for STL classes in <pybind11/stl.h> will be used instead of generating custom STL bindings."),
+					 cl::init(false), cl::cat(BinderToolCategory));
+
 
 cl::opt<std::string> O_root_module("root-module", cl::desc("Name of root module"), /*cl::init("example"),*/ cl::cat(BinderToolCategory));
 

--- a/source/options.cpp
+++ b/source/options.cpp
@@ -30,7 +30,7 @@ cl::opt<bool> O_verbose("v", cl::desc("Increase verbosity of output"), cl::init(
 cl::opt<bool> O_flat("flat", cl::desc("When specified generated files into single directory. Generated files will be named as <root-module>.cpp, <root-module>_1.cpp, <root-module>_2.cpp, ... etc."),
 					 cl::init(false), cl::cat(BinderToolCategory));
 
-cl::opt<bool> O_stl("stl", cl::desc("When specified bindings for STL classes in <pybind11/stl.h> will be used instead of generating custom STL bindings."),
+cl::opt<bool> O_include_pybind11_stl("include-pybind11-stl", cl::desc("When specified bindings for STL classes in <pybind11/stl.h> will be used instead of generating custom STL bindings."),
 					 cl::init(false), cl::cat(BinderToolCategory));
 
 

--- a/source/options.hpp
+++ b/source/options.hpp
@@ -24,7 +24,7 @@ extern llvm::cl::opt<bool> O_single_file;
 extern llvm::cl::opt<bool> O_trace;
 extern llvm::cl::opt<bool> O_verbose;
 extern llvm::cl::opt<bool> O_flat;
-extern llvm::cl::opt<bool> O_stl;
+extern llvm::cl::opt<bool> O_include_pybind11_stl;
 
 extern llvm::cl::opt<std::string> O_root_module;
 extern llvm::cl::opt<int> O_max_file_size;

--- a/source/options.hpp
+++ b/source/options.hpp
@@ -24,6 +24,7 @@ extern llvm::cl::opt<bool> O_single_file;
 extern llvm::cl::opt<bool> O_trace;
 extern llvm::cl::opt<bool> O_verbose;
 extern llvm::cl::opt<bool> O_flat;
+extern llvm::cl::opt<bool> O_stl;
 
 extern llvm::cl::opt<std::string> O_root_module;
 extern llvm::cl::opt<int> O_max_file_size;

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -746,7 +746,7 @@ bool is_python_builtin(NamedDecl const *C)
 	if (Config::get().python_builtins.count(name) || known_builtin.count(name))
 		return true;
 	// STL
-	if (O_stl && Config::get().stl_builtin.count(name))
+	if (O_include_pybind11_stl && Config::get().stl_builtin.count(name))
 		return true;
 
 	return false;

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -653,7 +653,7 @@ bool is_python_builtin(NamedDecl const *C)
 	string name = standard_name(C->getQualifiedNameAsString());
 	// if( begins_with(name, "class ") ) name = name.substr(6); // len("class ")
 
-	static std::vector<string> const known_builtin = {
+	static std::set<string> const known_builtin = {
 		//"std::nullptr_t", "nullptr_t",
 		"std::basic_string", "std::initializer_list", "std::__1::basic_string",
 
@@ -683,8 +683,6 @@ bool is_python_builtin(NamedDecl const *C)
 		"std::__hash_value_type",
 
 		"std::function", "std::complex",
-
-		"std::optional",
 
 		// pybind11 types
 		// https://pybind11.readthedocs.io/en/stable/advanced/pycpp/object.html
@@ -716,7 +714,6 @@ bool is_python_builtin(NamedDecl const *C)
 		"pybind11::frozenset",
 		"pybind11::set",
 		"pybind11::function",
-		"pybind11::function",
 		"pybind11::cpp_function",
 		"pybind11::staticmethod",
 		"pybind11::buffer",
@@ -725,17 +722,32 @@ bool is_python_builtin(NamedDecl const *C)
 		"pybind11::array_t",
 	};
 
+	static std::set<string> const stl_builtin = {
+		"std::vector",
+		"std::deque",
+		"std::list",
+		"std::array",
+		"std::valarray",
+		"std::set",
+		"std::unordered_set",
+		"std::map",
+		"std::unordered_map",
+		// C++14
+		"std::experimental::optional",
+		// C++17
+		"std::optional",
+		"std::variant",
+	};
+
 	// Not builtin's
-	for ( const auto &k : Config::get().not_python_builtins ) {
-		if ( name == k ) return false;
-	}
+	if (Config::get().not_python_builtins.count(name))
+		return false;
 	// Builtins
-	for( const auto &k : known_builtin ) {
-		if( name == k ) return true;
-	}
-	for( const auto &k : Config::get().python_builtins ) {
-		if( name == k ) return true;
-	}
+	if (Config::get().python_builtins.count(name) || known_builtin.count(name))
+		return true;
+	// STL
+	if (O_stl && Config::get().stl_builtin.count(name))
+		return true;
 
 	return false;
 }

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -746,7 +746,7 @@ bool is_python_builtin(NamedDecl const *C)
 	if (Config::get().python_builtins.count(name) || known_builtin.count(name))
 		return true;
 	// STL
-	if (O_include_pybind11_stl && Config::get().stl_builtin.count(name))
+	if (O_include_pybind11_stl && stl_builtin.count(name))
 		return true;
 
 	return false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,20 +16,23 @@ else()
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${stestname}.config")
     SET(${stestname}_config_flag --config ${stestname}.config )
   endif()
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${stestname}.cli")
+    FILE(READ "${CMAKE_CURRENT_SOURCE_DIR}/${stestname}.cli" ${stestname}_cli_flags)
+  endif()
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${stestname}.hpp.include "#include <${stestname}.hpp>" )
   if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
     ADD_CUSTOM_TARGET(target${stestnamenodot}cpp
     #The first two expressions below are for older clang
     COMMAND C_INCLUDE_PATH=${LibClang_INCLUDE_DIR}:/Library/Developer/CommandLineTools/usr/include/c++/v1/  CPLUS_INCLUDE_PATH=${LibClang_INCLUDE_DIR}:/Library/Developer/CommandLineTools/usr/include/c++/v1/
       ${CMAKE_BINARY_DIR}/source/binder --bind ""  -max-file-size=100000
-      --root-module ${stestnamenodot} --prefix ${CMAKE_CURRENT_BINARY_DIR}/ ${${stestname}_config_flag} --single-file  --annotate-includes  ${CMAKE_CURRENT_BINARY_DIR}/${stestname}.hpp.include  
+      --root-module ${stestnamenodot} --prefix ${CMAKE_CURRENT_BINARY_DIR}/ ${${stestname}_config_flag} --single-file  --annotate-includes  ${CMAKE_CURRENT_BINARY_DIR}/${stestname}.hpp.include ${${stestname}_cli_flags}
       -- -x c++ -std=c++11   -I . -I ${CMAKE_CURRENT_SOURCE_DIR}  -isystem /  -I ${CLANG_INCLUDE_DIRS}   -iwithsysroot${LibClang_INCLUDE_DIR}
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" VERBATIM)
   else()
     ADD_CUSTOM_TARGET(target${stestnamenodot}cpp
     #The first two expressions below are for older clang
     COMMAND C_INCLUDE_PATH=${LibClang_INCLUDE_DIR}   CPLUS_INCLUDE_PATH=${LibClang_INCLUDE_DIR}  ${CMAKE_BINARY_DIR}/source/binder --bind ""  -max-file-size=100000
-      --root-module ${stestnamenodot} --prefix ${CMAKE_CURRENT_BINARY_DIR}/ ${${stestname}_config_flag} --single-file  --annotate-includes  ${CMAKE_CURRENT_BINARY_DIR}/${stestname}.hpp.include  
+      --root-module ${stestnamenodot} --prefix ${CMAKE_CURRENT_BINARY_DIR}/ ${${stestname}_config_flag} --single-file  --annotate-includes  ${CMAKE_CURRENT_BINARY_DIR}/${stestname}.hpp.include ${${stestname}_cli_flags}
       -- -x c++ -std=c++11   -I . -I ${CMAKE_CURRENT_SOURCE_DIR}  -isystem /  -I ${CLANG_INCLUDE_DIRS}   -iwithsysroot${LibClang_INCLUDE_DIR}
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" VERBATIM)
   endif()
@@ -43,10 +46,10 @@ macro( binder_test testname vers)
   list(GET MAJMIN 1 MIN)
   if (${MAJ} STREQUAL 0 )
     if (NOT TARGET diffbinder)
-      add_executable( diffbinder diffbinder.cpp) 
+      add_executable( diffbinder diffbinder.cpp)
     endif()
     add_test( NAME ${testname}_diff
-#--always-success option forces the diffbinder to return success regardles of the results of comparison. 
+#--always-success option forces the diffbinder to return success regardles of the results of comparison.
       COMMAND diffbinder  ${CMAKE_CURRENT_BINARY_DIR}/${testnamenodot}.cpp ${CMAKE_CURRENT_SOURCE_DIR}/${testname}.ref --always-success
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
     set_source_files_properties( ${CMAKE_CURRENT_BINARY_DIR}/${testnamenodot}.cpp PROPERTIES GENERATED TRUE)
@@ -62,18 +65,18 @@ macro( binder_test testname vers)
     add_dependencies(${testnamenodot}${vers}  target${testnamenodot}cpp)
     set_target_properties(${testnamenodot}${vers} PROPERTIES OUTPUT_NAME  ${testnamenodot}
                                                NO_SYSTEM_FROM_IMPORTED ON
-                                               ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/py${vers}/${CMAKE_INSTALL_LIBDIR}/$<0:> 
+                                               ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/py${vers}/${CMAKE_INSTALL_LIBDIR}/$<0:>
                                                LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/py${vers}/${CMAKE_INSTALL_LIBDIR}/$<0:>
                                                RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/py${vers}/${CMAKE_INSTALL_LIBDIR}/$<0:>)
     target_compile_definitions(${testnamenodot}${vers} PRIVATE ${testnamenodot}_EXPORTS )
     target_include_directories( ${testnamenodot}${vers} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}  ${pybind11_INCLUDE_DIR})
 
     if(BINDER_USE_PYTHON_IN_TEST)
-      add_test( NAME ${testname}_python${vers} 
+      add_test( NAME ${testname}_python${vers}
         COMMAND ${Python_EXECUTABLE} -c "import ${testnamenodot}"
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/py${vers}/${CMAKE_INSTALL_LIBDIR}/$<0:>)
     else()
-      add_test( NAME ${testname}_python${vers} 
+      add_test( NAME ${testname}_python${vers}
         COMMAND echo "Import for ${testnamenodot} is disabled"
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/py${vers}/${CMAKE_INSTALL_LIBDIR}/$<0:>)
     endif()
@@ -105,6 +108,7 @@ set( binder_tests
          T42.stl.names.set
          T42.stl.names.multimap
          T42.stl.names.multiset
+         T43.stl.pybind11_include_stl
          T50.namespace_binder
          )
 if (pybind11_VERSION VERSION_LESS 2.5.99)

--- a/test/T43.stl.pybind11_include_stl.cli
+++ b/test/T43.stl.pybind11_include_stl.cli
@@ -1,0 +1,1 @@
+--include-pybind11-stl

--- a/test/T43.stl.pybind11_include_stl.config
+++ b/test/T43.stl.pybind11_include_stl.config
@@ -1,0 +1,1 @@
++namespace TestSTLInc

--- a/test/T43.stl.pybind11_include_stl.hpp
+++ b/test/T43.stl.pybind11_include_stl.hpp
@@ -1,0 +1,40 @@
+#ifndef _INCLUDED_T40_pybind11_include_stl_hpp_
+#define _INCLUDED_T40_pybind11_include_stl_hpp_
+
+#include <vector>
+#include <deque>
+#include <list>
+#include <array>
+#include <valarray>
+#include <set>
+#include <unordered_set>
+#include <map>
+#include <unordered_map>
+
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+	//C++17
+	#include <optional>
+	#include <variant>
+#endif
+
+// Not testing C++14 #include <experimental/optional> b/c it doesn't exist for everyone
+
+void test_include_stl(
+	std::vector<int>,
+	std::deque<int>,
+	std::list<int>,
+	std::array<int,5>,
+	std::valarray<int>,
+	std::set<int>,
+	std::unordered_set<int>,
+	std::map<int,int>,
+	std::unordered_map<int,int>
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+    // C++17
+	,
+	std::optional<int>,
+	std::variant<int, bool>
+#endif
+) {}
+
+#endif // _INCLUDED_T43_pybind11_include_stl_hpp_

--- a/test/T43.stl.pybind11_include_stl.ref
+++ b/test/T43.stl.pybind11_include_stl.ref
@@ -1,0 +1,97 @@
+// File: T43_stl_pybind11_include_stl.cpp
+#include <T43.stl.pybind11_include_stl.hpp> // test_include_stl
+#include <array> // std::array
+#include <deque> // std::deque
+#include <functional> // std::equal_to
+#include <functional> // std::less
+#include <iterator> // __gnu_cxx::__normal_iterator
+#include <list> // std::list
+#include <map> // std::_Rb_tree_const_iterator
+#include <map> // std::_Rb_tree_iterator
+#include <map> // std::map
+#include <memory> // std::allocator
+#include <set> // std::set
+#include <unordered_map> // std::__detail::_Node_const_iterator
+#include <unordered_map> // std::__detail::_Node_iterator
+#include <unordered_map> // std::unordered_map
+#include <unordered_set> // std::unordered_set
+#include <utility> // std::pair
+#include <valarray> // std::valarray
+#include <vector> // std::vector
+
+#include <functional>
+#include <pybind11/pybind11.h>
+#include <string>
+#include <pybind11/stl.h>
+
+
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+	#define BINDER_PYBIND11_TYPE_CASTER
+	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
+#endif
+
+void bind_T43_stl_pybind11_include_stl(std::function< pybind11::module &(std::string const &namespace_) > &M)
+{
+	// test_include_stl(class std::vector<int>, class std::deque<int>, class std::list<int>, struct std::array<int, 5>, class std::valarray<int>, class std::set<int>, class std::unordered_set<int>, class std::map<int, int>, class 
+std::unordered_map<int, int>) file:T43.stl.pybind11_include_stl.hpp line:22
+	M("").def("test_include_stl", (void (*)(class std::vector<int>, class std::deque<int>, class std::list<int>, struct std::array<int, 5>, class std::valarray<int>, class std::set<int>, class std::unordered_set<int>, class std::map<int, int>, 
+class std::unordered_map<int, int>)) &test_include_stl, "C++: test_include_stl(class std::vector<int>, class std::deque<int>, class std::list<int>, struct std::array<int, 5>, class std::valarray<int>, class std::set<int>, class 
+std::unordered_set<int>, class std::map<int, int>, class std::unordered_map<int, int>) --> void", pybind11::arg(""), pybind11::arg(""), pybind11::arg(""), pybind11::arg(""), pybind11::arg(""), pybind11::arg(""), pybind11::arg(""), pybind11::arg(""), 
+pybind11::arg(""));
+
+}
+
+
+#include <map>
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <pybind11/pybind11.h>
+
+typedef std::function< pybind11::module & (std::string const &) > ModuleGetter;
+
+void bind_T43_stl_pybind11_include_stl(std::function< pybind11::module &(std::string const &namespace_) > &M);
+
+
+PYBIND11_MODULE(T43_stl_pybind11_include_stl, root_module) {
+	root_module.doc() = "T43_stl_pybind11_include_stl module";
+
+	std::map <std::string, pybind11::module> modules;
+	ModuleGetter M = [&](std::string const &namespace_) -> pybind11::module & {
+		auto it = modules.find(namespace_);
+		if( it == modules.end() ) throw std::runtime_error("Attempt to access pybind11::module for namespace " + namespace_ + " before it was created!!!");
+		return it->second;
+	};
+
+	modules[""] = root_module;
+
+	static std::vector<std::string> const reserved_python_words {"nonlocal", "global", };
+
+	auto mangle_namespace_name(
+		[](std::string const &ns) -> std::string {
+			if ( std::find(reserved_python_words.begin(), reserved_python_words.end(), ns) == reserved_python_words.end() ) return ns;
+			else return ns+'_';
+		}
+	);
+
+	std::vector< std::pair<std::string, std::string> > sub_modules {
+	};
+	for(auto &p : sub_modules ) modules[p.first.size() ? p.first+"::"+p.second : p.second] = modules[p.first].def_submodule( mangle_namespace_name(p.second).c_str(), ("Bindings for " + p.first + "::" + p.second + " namespace").c_str() );
+
+	//pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
+
+	bind_T43_stl_pybind11_include_stl(M);
+
+}
+
+// Source list file: /build/test//T43_stl_pybind11_include_stl.sources
+// T43_stl_pybind11_include_stl.cpp
+// T43_stl_pybind11_include_stl.cpp
+
+// Modules list file: /build/test//T43_stl_pybind11_include_stl.modules
+//


### PR DESCRIPTION
This PR labels pybind11 objects as builtins. For example `pybind11::dict` and `pybind11::list`.