### PR TITLE
pybind11 bindings

### DIFF
--- a/source/type.cpp
+++ b/source/type.cpp
@@ -686,7 +686,43 @@ bool is_python_builtin(NamedDecl const *C)
 
 		"std::optional",
 
+		// pybind11 types
+		// https://pybind11.readthedocs.io/en/stable/advanced/pycpp/object.html
+		// https://pybind11.readthedocs.io/en/stable/reference.html
+		"pybind11::handle",
+		"pybind11::object",
+		"pybind11::module_",
+		"pybind11::iterator",
+		"pybind11::type",
+		"pybind11::iterable",
+		"pybind11::str",
+		"pybind11::bytes",
+		"pybind11::bytesarray",
+		"pybind11::none",
+		"pybind11::ellipsis",
+		"pybind11::bool_",
+		"pybind11::int_",
+		"pybind11::float_",
+		"pybind11::weakref",
+		"pybind11::slice",
+		"pybind11::capsule",
+		"pybind11::tuple",
+		"pybind11::args",
 		"pybind11::dict",
+		"pybind11::kwargs",
+		"pybind11::sequence",
+		"pybind11::list",
+		"pybind11::anyset",
+		"pybind11::frozenset",
+		"pybind11::set",
+		"pybind11::function",
+		"pybind11::function",
+		"pybind11::cpp_function",
+		"pybind11::staticmethod",
+		"pybind11::buffer",
+		"pybind11::memoryview",
+		"pybind11::array",
+		"pybind11::array_t",
 	};
 
 	for( auto &k : known_builtin ) {

--- a/test/T60.pybind11.hpp
+++ b/test/T60.pybind11.hpp
@@ -11,4 +11,45 @@
 #include <string>
 #include <pybind11/stl.h>
 
-std::string foo_dict(pybind11::dict& d) { return pybind11::repr(d); }
+#define TEST_PY_FN(TYPE) \
+	void test_py_##TYPE(pybind11::TYPE &) {}
+
+TEST_PY_FN(handle);
+TEST_PY_FN(object);
+TEST_PY_FN(module);
+TEST_PY_FN(iterator);
+TEST_PY_FN(type);
+TEST_PY_FN(module_);
+TEST_PY_FN(iterator);
+TEST_PY_FN(type);
+TEST_PY_FN(iterable);
+TEST_PY_FN(str);
+TEST_PY_FN(bytes);
+TEST_PY_FN(bytesarray);
+TEST_PY_FN(none);
+TEST_PY_FN(ellipsis);
+TEST_PY_FN(bool_);
+TEST_PY_FN(int_);
+TEST_PY_FN(float_);
+TEST_PY_FN(weakref);
+TEST_PY_FN(slice);
+TEST_PY_FN(capsule);
+TEST_PY_FN(tuple);
+TEST_PY_FN(args);
+TEST_PY_FN(dict);
+TEST_PY_FN(kwargs);
+TEST_PY_FN(sequence);
+TEST_PY_FN(list);
+TEST_PY_FN(anyset);
+TEST_PY_FN(frozenset);
+TEST_PY_FN(set);
+TEST_PY_FN(function);
+TEST_PY_FN(function);
+TEST_PY_FN(cpp_function);
+TEST_PY_FN(staticmethod);
+TEST_PY_FN(buffer);
+TEST_PY_FN(memoryview);
+TEST_PY_FN(array);
+TEST_PY_FN(array_t);
+
+#undef TEST_PY_FN


### PR DESCRIPTION
This PR labels pybind11 objects as builtins. For example `pybind11::dict` and `pybind11::list`.