### PR TITLE
Add mod support

### DIFF
--- a/source/function.cpp
+++ b/source/function.cpp
@@ -45,11 +45,13 @@ static std::map<string, string > const cpp_python_operator_map{
 	{"operator-", "__sub__"}, //
 	{"operator*", "__mul__"}, //
 	{"operator/", "__div__"}, //
+	{"operator%", "__mod__"}, //
 
 	{"operator+=", "__iadd__"}, //
 	{"operator-=", "__isub__"}, //
 	{"operator*=", "__imul__"}, //
 	{"operator/=", "__idiv__"}, //
+	{"operator%=", "__imod__"}, //
 
 	{"operator()", "__call__"}, //
 	{"operator==", "__eq__"}, //

--- a/test/T12.operator.hpp
+++ b/test/T12.operator.hpp
@@ -18,11 +18,13 @@ struct T
 	T &operator-(int) { return *this; }
 	T &operator*(int) { return *this; }
 	T &operator/(int) { return *this; }
+	T &operator%(int) { return *this; }
 
 	void operator+=(int) {}
 	void operator-=(int) {}
 	void operator*=(int) {}
 	void operator/=(int) {}
+	void operator%=(int) {}
 
 	void operator()(int) {}
 

--- a/test/T12.operator.ref
+++ b/test/T12.operator.ref
@@ -22,10 +22,12 @@ void bind_T12_operator(std::function< pybind11::module &(std::string const &name
 		cl.def("__sub__", (struct T & (T::*)(int)) &T::operator-, "C++: T::operator-(int) --> struct T &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 		cl.def("__mul__", (struct T & (T::*)(int)) &T::operator*, "C++: T::operator*(int) --> struct T &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 		cl.def("__div__", (struct T & (T::*)(int)) &T::operator/, "C++: T::operator/(int) --> struct T &", pybind11::return_value_policy::automatic, pybind11::arg(""));
+		cl.def("__mod__", (struct T & (T::*)(int)) &T::operator%, "C++: T::operator%(int) --> struct T &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 		cl.def("__iadd__", (void (T::*)(int)) &T::operator+=, "C++: T::operator+=(int) --> void", pybind11::arg(""));
 		cl.def("__isub__", (void (T::*)(int)) &T::operator-=, "C++: T::operator-=(int) --> void", pybind11::arg(""));
 		cl.def("__imul__", (void (T::*)(int)) &T::operator*=, "C++: T::operator*=(int) --> void", pybind11::arg(""));
 		cl.def("__idiv__", (void (T::*)(int)) &T::operator/=, "C++: T::operator/=(int) --> void", pybind11::arg(""));
+		cl.def("__imod__", (void (T::*)(int)) &T::operator%=, "C++: T::operator%=(int) --> void", pybind11::arg(""));
 		cl.def("__call__", (void (T::*)(int)) &T::operator(), "C++: T::operator()(int) --> void", pybind11::arg(""));
 		cl.def("__eq__", (bool (T::*)(const struct T &)) &T::operator==, "C++: T::operator==(const struct T &) --> bool", pybind11::arg(""));
 		cl.def("__ne__", (bool (T::*)(const struct T &)) &T::operator!=, "C++: T::operator!=(const struct T &) --> bool", pybind11::arg(""));
@@ -87,4 +89,4 @@ PYBIND11_MODULE(T12_operator, root_module) {
 // T12_operator.cpp
 
 // Modules list file: TEST/T12_operator.modules
-// 
+//


### PR DESCRIPTION
Support for `operator%` and `operator%=`

It should be worth noting that `%` in C++ and `%` in python are not exact analogs for each other. For example `-7%3` gives `-1` in `C++` and `2` in python. Both are mathematically valid, but python typically also requires the result be positive, it's more of a division remainder. These would only be binding for custom classes / definitions though so I think this is ok to gloss over.