### PR TITLE
Fix unary operators

### DIFF
--- a/documentation/limitations.rst
+++ b/documentation/limitations.rst
@@ -74,6 +74,6 @@ The following operators will be ignored by binder:
 Miscellaneous
 -------------
 
-1.   The pre/post increment operators both map to ``plus_plus`, with the pre-increment operator being invoked via ``a.plus_plus()`` and post-increment via ``.plus_plus(0)``; just as the operators are technically defined in C++. The same is true for the pre/post decrement operators, both called ``minus_minus``.
+1.   The pre/post increment operators both map to ``plus_plus``, with the pre-increment operator being invoked via ``a.plus_plus()`` and post-increment via ``.plus_plus(0)``; just as the operators are technically defined in C++. The same is true for the pre/post decrement operators, both called ``minus_minus``.
 
 2.   User defined literals ``operator"" _foo`` end up being named as ``operator_foo``.

--- a/documentation/limitations.rst
+++ b/documentation/limitations.rst
@@ -77,11 +77,3 @@ Miscellaneous
 1.   The pre/post increment operators both map to ``plus_plus`, with the pre-increment operator being invoked via ``a.plus_plus()`` and post-increment via ``.plus_plus(0)``; just as the operators are technically defined in C++. The same is true for the pre/post decrement operators, both called ``minus_minus``.
 
 2.   User defined literals ``operator"" _foo`` end up being named as ``operator_foo``.
-
-----------
-Known Bugs
-----------
-
-1.   The unary ``operator+`` and unary ``operator-`` currently map to ``__add__`` and ``__sub__`` rather than ``__pos__`` and ``__neg__``.
-
-2.   The unary ``operator*`` (dereference operator) will currently map to ``__mul__``.

--- a/source/function.cpp
+++ b/source/function.cpp
@@ -41,6 +41,8 @@ using namespace fmt::literals;
 namespace binder {
 
 // Return the python operator that maps to the C++ operator; returns "" if no mapping exists
+// This correctly handles operators that have multiple meanings depending on their argument count
+// For example, operator_(this, other) maps to __sub__ while operator-(this) maps to __neg__
 string cpp_python_operator(const FunctionDecl & F) {
 	static std::map<string, vector<string>> const m {
 		{"operator+", {"__pos__", "__add__"}}, //
@@ -79,11 +81,8 @@ string cpp_python_operator(const FunctionDecl & F) {
 	const auto & found = m.find(F.getNameAsString());
 	if (found != m.end()) {
 		const auto & vec { found->second };
-		if (vec.size() == 1) { return vec[0]; }
 		const auto n = F.getNumParams();
-		if (vec.size() > n) {
-			return vec[n];
-		}
+		return n < vec.size() ? vec[n] : vec.back();
 	}
 	return {};
 }

--- a/source/function.cpp
+++ b/source/function.cpp
@@ -71,8 +71,8 @@ string cpp_python_operator(const FunctionDecl & F) {
 		{"operator!=", {"__ne__"}}, //
 		{"operator[]", {"__getitem__"}}, //
 		{"operator=", {"assign"}}, //
-		{"operator++", {"pre_increment", "pre_increment"}}, //
-		{"operator--", {"pre_decrement", "post_decrement"}}, //
+		{"operator++", {"plus_plus"}}, //
+		{"operator--", {"minus_minus"}}, //
 
 		{"operator->", {"arrow"}} //
   };

--- a/test/T12.operator.hpp
+++ b/test/T12.operator.hpp
@@ -16,6 +16,10 @@ struct T
 {
 	T &operator~() { return *this; }
 
+	T &operator+() { return *this; }
+	T &operator-() { return *this; }
+	T &operator*() { return *this; }
+
 	T &operator+(int) { return *this; }
 	T &operator-(int) { return *this; }
 	T &operator*(int) { return *this; }

--- a/test/T12.operator.ref
+++ b/test/T12.operator.ref
@@ -19,6 +19,9 @@ void bind_T12_operator(std::function< pybind11::module &(std::string const &name
 		pybind11::class_<T, std::shared_ptr<T>> cl(M(""), "T", "");
 		cl.def( pybind11::init( [](){ return new T(); } ) );
 		cl.def("__invert__", (struct T & (T::*)()) &T::operator~, "C++: T::operator~() --> struct T &", pybind11::return_value_policy::automatic);
+		cl.def("__pos__", (struct T & (T::*)()) &T::operator+, "C++: T::operator+() --> struct T &", pybind11::return_value_policy::automatic);
+		cl.def("__neg__", (struct T & (T::*)()) &T::operator-, "C++: T::operator-() --> struct T &", pybind11::return_value_policy::automatic);
+		cl.def("dereference", (struct T & (T::*)()) &T::operator*, "C++: T::operator*() --> struct T &", pybind11::return_value_policy::automatic);
 		cl.def("__add__", (struct T & (T::*)(int)) &T::operator+, "C++: T::operator+(int) --> struct T &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 		cl.def("__sub__", (struct T & (T::*)(int)) &T::operator-, "C++: T::operator-(int) --> struct T &", pybind11::return_value_policy::automatic, pybind11::arg(""));
 		cl.def("__mul__", (struct T & (T::*)(int)) &T::operator*, "C++: T::operator*(int) --> struct T &", pybind11::return_value_policy::automatic, pybind11::arg(""));
@@ -100,4 +103,4 @@ PYBIND11_MODULE(T12_operator, root_module) {
 // T12_operator.cpp
 
 // Modules list file: TEST/T12_operator.modules
-// 
+//


### PR DESCRIPTION
This fixes: https://github.com/RosettaCommons/binder/issues/225

It also addresses https://github.com/RosettaCommons/binder/issues/226 by renaming `plus_plus` to `pre_increment` or `post_increment` depending on which is called. It unfortunately does not fix the issue that the post increment operator requires an integer argument. I'm not sure how to fix that. If this is not ok, I can undo this fix and only let this PR address https://github.com/RosettaCommons/binder/issues/225