### PR TITLE
The documentation has a bad reference

### DIFF
--- a/documentation/install.rst
+++ b/documentation/install.rst
@@ -209,13 +209,13 @@ If ``binder`` was build with some older versions of LLVM, one could also set the
 
 
 
-.. _building-static:
-
 With Docker
 ***********
 
 An example `Dockerfile` for building binder can be found in the ``binder`` repository linked here: https://github.com/RosettaCommons/binder/examples
 
+
+.. _building-static:
 
 Building Statically (Linux only)
 ********************************


### PR DESCRIPTION
This should hopefully fix
> To statically compile binder, see [With Docker](https://cppbinder.readthedocs.io/en/latest/install.html#building-static).

With
> To statically compile binder, see [Building Statically (Linux only)](https://cppbinder.readthedocs.io/en/latest/install.html#building-static).