### PR TITLE
Add module_local option for namespace to the configuration script

### DIFF
--- a/source/class.cpp
+++ b/source/class.cpp
@@ -1194,15 +1194,22 @@ void ClassBinder::bind(Context &context)
 	}
 	string maybe_trampoline = callback_structure_constructible ? ", " + binding_qualified_name : "";
 
+	// Add module local if requested for the namespace
+	std::string module_local_annotation = "";
+	if (Config::get().is_module_local_requested(namespace_from_named_decl(C)))
+		module_local_annotation = ", pybind11::module_local()";
+
 	// Add buffer protocol if requested
 	std::string buffer_protocol_annotation = "";
 	if (Config::get().is_buffer_protocol_requested(qualified_name_without_template))
 		buffer_protocol_annotation = ", pybind11::buffer_protocol()";
 
+	std::string extra_annotation = module_local_annotation + buffer_protocol_annotation;
+
 	if( named_class )
 		c += '\t' +
 			 R"(pybind11::class_<{}{}{}{}> cl({}, "{}", "{}"{});)"_format(qualified_name, maybe_holder_type, maybe_trampoline, maybe_base_classes(context), module_variable_name, python_class_name(C),
-																		generate_documentation_string_for_declaration(C), buffer_protocol_annotation) +
+																		generate_documentation_string_for_declaration(C), extra_annotation) +
 			 '\n';
 	// c += "\tpybind11::handle cl_type = cl;\n\n";
 

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -65,6 +65,7 @@ void Config::read(string const &file_name)
 	string const _include_for_namespace_{"include_for_namespace"};
 
 	string const _buffer_protocol_{"buffer_protocol"};
+	string const _module_local_{"module_local"};
 
 	string const _binder_{"binder"};
 	string const _add_on_binder_{"add_on_binder"};
@@ -159,6 +160,11 @@ void Config::read(string const &file_name)
 		else if( token == _buffer_protocol_ ) {
 			if(bind) {
 				buffer_protocols.push_back(name_without_spaces);
+			}
+		}
+		else if( token == _module_local_) {
+			if(bind) {
+				module_local_namespaces.push_back(name_without_spaces);
 			}
 		}
 		else if( token == _binder_ ) {
@@ -344,6 +350,20 @@ bool Config::is_buffer_protocol_requested(string const &class__) const
 
 	if( buffer_protocol != buffer_protocols.end() ) {
 		// outs() << "Using buffer protocol for class : " << class_ << "\n";
+		return true;
+	}
+
+	return false;
+}
+
+bool Config::is_module_local_requested(string const &namespace_) const
+{
+	const string namespace_all = "ALL";
+	auto module_local_all = std::find(module_local_namespaces.begin(), module_local_namespaces.end(), namespace_all);
+	auto module_local = std::find(module_local_namespaces.begin(), module_local_namespaces.end(), namespace_);
+
+	if( module_local != module_local_namespaces.end() || module_local_all != module_local_namespaces.end()) {
+		// outs() << "Using module local for namespace : " << namespace_ << "\n";
 		return true;
 	}
 

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -62,7 +62,7 @@ public:
 	string root_module;
 
 	std::vector<string> namespaces_to_bind, classes_to_bind, functions_to_bind, namespaces_to_skip, classes_to_skip, functions_to_skip, includes_to_add, includes_to_skip;
-	std::vector<string> buffer_protocols, module_local_namespaces;
+	std::vector<string> buffer_protocols, module_local_namespaces_to_add, module_local_namespaces_to_skip;
 
 	std::map<string, string> const &binders() const { return binders_; }
 	std::map<string, string> const &add_on_binders() const { return add_on_binders_; }

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -62,7 +62,7 @@ public:
 	string root_module;
 
 	std::vector<string> namespaces_to_bind, classes_to_bind, functions_to_bind, namespaces_to_skip, classes_to_skip, functions_to_skip, includes_to_add, includes_to_skip;
-	std::vector<string> buffer_protocols;
+	std::vector<string> buffer_protocols, module_local_namespaces;
 
 	std::map<string, string> const &binders() const { return binders_; }
 	std::map<string, string> const &add_on_binders() const { return add_on_binders_; }
@@ -93,6 +93,7 @@ public:
 	/// check if user requested binding for given declaration
 	bool is_namespace_binding_requested(string const &namespace_) const;
 	bool is_namespace_skipping_requested(string const &namespace_) const;
+	bool is_module_local_requested(string const &namespace_) const;
 
 	bool is_function_binding_requested(string const &function) const;
 	bool is_function_skipping_requested(string const &function) const;

--- a/source/enum.cpp
+++ b/source/enum.cpp
@@ -94,7 +94,12 @@ std::string bind_enum(std::string const &module, EnumDecl const *E)
 
 	string maybe_arithmetic = E->isScoped() ? "" : ", pybind11::arithmetic()";
 
-	string r = "\tpybind11::enum_<{}>({}, \"{}\"{}, \"{}\")\n"_format(qualified_name, module, name, maybe_arithmetic, generate_documentation_string_for_declaration(E));
+	// Add module local if requested for the namespace
+	std::string module_local_annotation = "";
+	if (Config::get().is_module_local_requested(namespace_from_named_decl(E)))
+		module_local_annotation = ", pybind11::module_local()";
+
+	string r = "\tpybind11::enum_<{}>({}, \"{}\"{}, \"{}\"{})\n"_format(qualified_name, module, name, maybe_arithmetic, generate_documentation_string_for_declaration(E), module_local_annotation);
 
 	// r += "\t // is_bindable " + E->getNameAsString() + " -> " + std::to_string(is_bindable(E)) + "\n";
 

--- a/test/T70.module_local.config
+++ b/test/T70.module_local.config
@@ -1,0 +1,1 @@
++module_local ALL

--- a/test/T70.module_local.config
+++ b/test/T70.module_local.config
@@ -1,1 +1,2 @@
-+module_local ALL
++module_local_namespace @all_namespaces
+-module_local_namespace bbb

--- a/test/T70.module_local.hpp
+++ b/test/T70.module_local.hpp
@@ -1,0 +1,109 @@
+// -*- mode:c++;tab-width:2;indent-tabs-mode:t;show-trailing-whitespace:t;rm-trailing-spaces:t -*-
+// vi: set ts=2 noet:
+//
+// Copyright (c) 2016 Sergey Lyskov <sergey.lyskov@jhu.edu>
+//
+// All rights reserved. Use of this source code is governed by a
+// MIT license that can be found in the LICENSE file.
+
+/// @file   binder/test/T07.class.hpp
+/// @brief  Binder self-test file. Bindings of classes data members functionality.
+/// @author Sergey Lyskov
+
+#ifndef _INCLUDED_T07_class_hpp_
+#define _INCLUDED_T07_class_hpp_
+
+struct Integral
+{
+	int i;
+	unsigned int ui;
+	long l;
+	unsigned long ul;
+};
+
+struct Floating_point
+{
+	float f;
+	double d;
+	long double ld;
+};
+
+struct Arrays
+{
+	int i__not_binded[8];
+	int ii_not_binded[8][8];
+	float f__not_binded[8];
+	float ff_not_binded[8][8];
+};
+
+struct Pointers_and_References
+{
+	Pointers_and_References() = delete;
+
+	int *ip_not_binded;
+	float *fp_not_binded;
+	int &i_r;
+	float &f_r;
+};
+
+
+class Consts
+{
+private:
+	int const private_int_not_binded = 1;
+	static int const private_static_not_binded;
+
+public:
+	Integral const public_Integral = Integral();
+	static Integral const static_public_Integral;
+
+	int const public_int = 1;
+	static int const public_static;
+
+	const int *ip_not_binded = nullptr;
+	const float *fp_not_binded = nullptr;
+};
+
+
+class Enums
+{
+public:
+	enum E1 { E1V = 2 };
+	enum class E2 { E2V = 4 };
+	enum class E3 {};
+
+protected:
+	enum EP0_not_binded { EP0V };
+
+private:
+	enum EP1_not_binded { EP1V };
+};
+
+
+class Access
+{
+public:
+	int i;
+	void foo_public(){};
+
+	static float foo(double) { return 1.0; }
+
+	static double a_double;
+
+protected:
+	int i_protected_not_binded;
+	void foo_protected_not_binded(){};
+
+private:
+	int i_not_binded;
+	void foo_private_not_binded(){};
+};
+
+
+struct ConstOverload
+{
+	void foo(int) {}
+	void foo(int) const {}
+};
+
+#endif // _INCLUDED_T07_class_hpp_

--- a/test/T70.module_local.ref
+++ b/test/T70.module_local.ref
@@ -1,0 +1,137 @@
+// File: T70_module_local.cpp
+#include <T70.module_local.hpp> // Access
+#include <T70.module_local.hpp> // Arrays
+#include <T70.module_local.hpp> // ConstOverload
+#include <T70.module_local.hpp> // Consts
+#include <T70.module_local.hpp> // Enums
+#include <T70.module_local.hpp> // Floating_point
+#include <T70.module_local.hpp> // Integral
+#include <T70.module_local.hpp> // Pointers_and_References
+#include <sstream> // __str__
+
+#include <functional>
+#include <pybind11/pybind11.h>
+#include <string>
+
+#ifndef BINDER_PYBIND11_TYPE_CASTER
+	#define BINDER_PYBIND11_TYPE_CASTER
+	PYBIND11_DECLARE_HOLDER_TYPE(T, std::shared_ptr<T>)
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
+#endif
+
+void bind_T70_module_local(std::function< pybind11::module &(std::string const &namespace_) > &M)
+{
+	{ // Integral file:T70.module_local.hpp line:16
+		pybind11::class_<Integral, std::shared_ptr<Integral>> cl(M(""), "Integral", "", pybind11::module_local());
+		cl.def( pybind11::init( [](Integral const &o){ return new Integral(o); } ) );
+		cl.def( pybind11::init( [](){ return new Integral(); } ) );
+		cl.def_readwrite("i", &Integral::i);
+		cl.def_readwrite("ui", &Integral::ui);
+		cl.def_readwrite("l", &Integral::l);
+		cl.def_readwrite("ul", &Integral::ul);
+		cl.def("assign", (struct Integral & (Integral::*)(const struct Integral &)) &Integral::operator=, "C++: Integral::operator=(const struct Integral &) --> struct Integral &", pybind11::return_value_policy::automatic, pybind11::arg(""));
+	}
+	{ // Floating_point file:T70.module_local.hpp line:24
+		pybind11::class_<Floating_point, std::shared_ptr<Floating_point>> cl(M(""), "Floating_point", "", pybind11::module_local());
+		cl.def( pybind11::init( [](){ return new Floating_point(); } ) );
+		cl.def_readwrite("f", &Floating_point::f);
+		cl.def_readwrite("d", &Floating_point::d);
+		cl.def_readwrite("ld", &Floating_point::ld);
+	}
+	{ // Arrays file:T70.module_local.hpp line:31
+		pybind11::class_<Arrays, std::shared_ptr<Arrays>> cl(M(""), "Arrays", "", pybind11::module_local());
+		cl.def( pybind11::init( [](){ return new Arrays(); } ) );
+	}
+	{ // Pointers_and_References file:T70.module_local.hpp line:39
+		pybind11::class_<Pointers_and_References, std::shared_ptr<Pointers_and_References>> cl(M(""), "Pointers_and_References", "", pybind11::module_local());
+	}
+	{ // Consts file:T70.module_local.hpp line:50
+		pybind11::class_<Consts, std::shared_ptr<Consts>> cl(M(""), "Consts", "", pybind11::module_local());
+		cl.def( pybind11::init( [](){ return new Consts(); } ) );
+		cl.def( pybind11::init( [](Consts const &o){ return new Consts(o); } ) );
+		cl.def_readonly("public_Integral", &Consts::public_Integral);
+		cl.def_readonly("public_int", &Consts::public_int);
+	}
+	{ // Enums file:T70.module_local.hpp line:68
+		pybind11::class_<Enums, std::shared_ptr<Enums>> cl(M(""), "Enums", "", pybind11::module_local());
+		cl.def( pybind11::init( [](){ return new Enums(); } ) );
+
+		pybind11::enum_<Enums::E1>(cl, "E1", pybind11::arithmetic(), "", pybind11::module_local())
+			.value("E1V", Enums::E1V)
+			.export_values();
+
+
+		pybind11::enum_<Enums::E2>(cl, "E2", "", pybind11::module_local())
+			.value("E2V", Enums::E2::E2V);
+
+
+		pybind11::enum_<Enums::E3>(cl, "E3", "", pybind11::module_local());
+
+	}
+	{ // Access file:T70.module_local.hpp line:83
+		pybind11::class_<Access, std::shared_ptr<Access>> cl(M(""), "Access", "", pybind11::module_local());
+		cl.def( pybind11::init( [](){ return new Access(); } ) );
+		cl.def_readwrite("i", &Access::i);
+		cl.def("foo_public", (void (Access::*)()) &Access::foo_public, "C++: Access::foo_public() --> void");
+		cl.def_static("foo", (float (*)(double)) &Access::foo, "C++: Access::foo(double) --> float", pybind11::arg(""));
+	}
+	{ // ConstOverload file:T70.module_local.hpp line:103
+		pybind11::class_<ConstOverload, std::shared_ptr<ConstOverload>> cl(M(""), "ConstOverload", "", pybind11::module_local());
+		cl.def( pybind11::init( [](){ return new ConstOverload(); } ) );
+		cl.def("foo", (void (ConstOverload::*)(int)) &ConstOverload::foo, "C++: ConstOverload::foo(int) --> void", pybind11::arg(""));
+	}
+}
+
+
+#include <map>
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <pybind11/pybind11.h>
+
+typedef std::function< pybind11::module & (std::string const &) > ModuleGetter;
+
+void bind_T70_module_local(std::function< pybind11::module &(std::string const &namespace_) > &M);
+
+
+PYBIND11_MODULE(T70_module_local, root_module) {
+	root_module.doc() = "T70_module_local module";
+
+	std::map <std::string, pybind11::module> modules;
+	ModuleGetter M = [&](std::string const &namespace_) -> pybind11::module & {
+		auto it = modules.find(namespace_);
+		if( it == modules.end() ) throw std::runtime_error("Attempt to access pybind11::module for namespace " + namespace_ + " before it was created!!!");
+		return it->second;
+	};
+
+	modules[""] = root_module;
+
+	static std::vector<std::string> const reserved_python_words {"nonlocal", "global", };
+
+	auto mangle_namespace_name(
+		[](std::string const &ns) -> std::string {
+			if ( std::find(reserved_python_words.begin(), reserved_python_words.end(), ns) == reserved_python_words.end() ) return ns;
+			else return ns+'_';
+		}
+	);
+
+	std::vector< std::pair<std::string, std::string> > sub_modules {
+	};
+	for(auto &p : sub_modules ) modules[p.first.size() ? p.first+"::"+p.second : p.second] = modules[p.first].def_submodule( mangle_namespace_name(p.second).c_str(), ("Bindings for " + p.first + "::" + p.second + " namespace").c_str() );
+
+	//pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
+
+	bind_T70_module_local(M);
+
+}
+
+// Source list file: TEST/T70_module_local.sources
+// T70_module_local.cpp
+// T70_module_local.cpp
+
+// Modules list file: TEST/T70_module_local.modules
+// 

--- a/test/T71.module_local.config
+++ b/test/T71.module_local.config
@@ -1,0 +1,1 @@
++module_local_namespace aaa

--- a/test/T71.module_local.hpp
+++ b/test/T71.module_local.hpp
@@ -6,11 +6,11 @@
 // All rights reserved. Use of this source code is governed by a
 // MIT license that can be found in the LICENSE file.
 
-/// @file   binder/test/T70.module_local.hpp
+/// @file   binder/test/T71.module_local.hpp
 /// @author Sergey Lyskov
 
-#ifndef _INCLUDED_T70_module_local_hpp_
-#define _INCLUDED_T70_module_local_hpp_
+#ifndef _INCLUDED_T71_module_local_hpp_
+#define _INCLUDED_T71_module_local_hpp_
 
 namespace aaa {
 	class A 
@@ -28,4 +28,4 @@ namespace bbb {
 	};
 }
 
-#endif // _INCLUDED_T70_module_local_hpp_
+#endif // _INCLUDED_T71_module_local_hpp_

--- a/test/T71.module_local.ref
+++ b/test/T71.module_local.ref
@@ -1,5 +1,5 @@
-// File: T70_module_local.cpp
-#include <T70.module_local.hpp> // aaa::A
+// File: T71_module_local.cpp
+#include <T71.module_local.hpp> // aaa::A
 #include <sstream> // __str__
 
 #include <functional>
@@ -13,9 +13,9 @@
 	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
-void bind_T70_module_local(std::function< pybind11::module &(std::string const &namespace_) > &M)
+void bind_T71_module_local(std::function< pybind11::module &(std::string const &namespace_) > &M)
 {
-	{ // aaa::A file:T70.module_local.hpp line:16
+	{ // aaa::A file:T71.module_local.hpp line:16
 		pybind11::class_<aaa::A, std::shared_ptr<aaa::A>> cl(M("aaa"), "A", "", pybind11::module_local());
 		cl.def( pybind11::init( [](){ return new aaa::A(); } ) );
 		cl.def("foo", (void (aaa::A::*)()) &aaa::A::foo, "C++: aaa::A::foo() --> void");
@@ -23,8 +23,8 @@ void bind_T70_module_local(std::function< pybind11::module &(std::string const &
 }
 
 
-// File: T70_module_local_1.cpp
-#include <T70.module_local.hpp> // bbb::B
+// File: T71_module_local_1.cpp
+#include <T71.module_local.hpp> // bbb::B
 #include <sstream> // __str__
 
 #include <functional>
@@ -38,9 +38,9 @@ void bind_T70_module_local(std::function< pybind11::module &(std::string const &
 	PYBIND11_MAKE_OPAQUE(std::shared_ptr<void>)
 #endif
 
-void bind_T70_module_local_1(std::function< pybind11::module &(std::string const &namespace_) > &M)
+void bind_T71_module_local_1(std::function< pybind11::module &(std::string const &namespace_) > &M)
 {
-	{ // bbb::B file:T70.module_local.hpp line:24
+	{ // bbb::B file:T71.module_local.hpp line:24
 		pybind11::class_<bbb::B, std::shared_ptr<bbb::B>> cl(M("bbb"), "B", "");
 		cl.def( pybind11::init( [](){ return new bbb::B(); } ) );
 		cl.def("foo", (void (bbb::B::*)()) &bbb::B::foo, "C++: bbb::B::foo() --> void");
@@ -59,12 +59,12 @@ void bind_T70_module_local_1(std::function< pybind11::module &(std::string const
 
 typedef std::function< pybind11::module & (std::string const &) > ModuleGetter;
 
-void bind_T70_module_local(std::function< pybind11::module &(std::string const &namespace_) > &M);
-void bind_T70_module_local_1(std::function< pybind11::module &(std::string const &namespace_) > &M);
+void bind_T71_module_local(std::function< pybind11::module &(std::string const &namespace_) > &M);
+void bind_T71_module_local_1(std::function< pybind11::module &(std::string const &namespace_) > &M);
 
 
-PYBIND11_MODULE(T70_module_local, root_module) {
-	root_module.doc() = "T70_module_local module";
+PYBIND11_MODULE(T71_module_local, root_module) {
+	root_module.doc() = "T71_module_local module";
 
 	std::map <std::string, pybind11::module> modules;
 	ModuleGetter M = [&](std::string const &namespace_) -> pybind11::module & {
@@ -92,15 +92,15 @@ PYBIND11_MODULE(T70_module_local, root_module) {
 
 	//pybind11::class_<std::shared_ptr<void>>(M(""), "_encapsulated_data_");
 
-	bind_T70_module_local(M);
-	bind_T70_module_local_1(M);
+	bind_T71_module_local(M);
+	bind_T71_module_local_1(M);
 
 }
 
-// Source list file: TEST/T70_module_local.sources
-// T70_module_local.cpp
-// T70_module_local.cpp
-// T70_module_local_1.cpp
+// Source list file: TEST/T71_module_local.sources
+// T71_module_local.cpp
+// T71_module_local.cpp
+// T71_module_local_1.cpp
 
-// Modules list file: TEST/T70_module_local.modules
+// Modules list file: TEST/T71_module_local.modules
 // aaa bbb 


### PR DESCRIPTION
This PR addresses #248 by adding an option to enable `module_local` for a namespace (using `+module_local namespace`) or for all the namespaces(using `+module_local ALL`).

@lyskov 