### PR TITLE
Remove the banned symbols from enum bindings. Note: the banned symbols function notes enums.

### DIFF
--- a/source/enum.cpp
+++ b/source/enum.cpp
@@ -126,7 +126,7 @@ string EnumBinder::id() const
 /// check if generator can create binding
 bool EnumBinder::bindable() const
 {
-	return is_bindable(E);
+	return is_bindable(E)  and !is_banned_symbol(E);
 }
 
 


### PR DESCRIPTION
Remove the banned symbols from enum bindings. Note: the banned symbols function notes enums.
Partial solution for #254 