### PR TITLE
Add option to skip binding a field

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -87,6 +87,11 @@ Config file directives:
   -class utility::pointer::ReferenceCount
   -class std::__weak_ptr
 
+* ``field``, specify if a particular field should be bound.
+
+.. code-block:: bash
+
+  -field MyClass::some_field
 
 
 * ``python_builtin``, specify if particular class/struct should be considered a python builtin and assume existing bindings for it already exist.

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -560,6 +560,10 @@ string binding_public_data_members(CXXRecordDecl const *C)
 				for( auto s = u->shadow_begin(); s != u->shadow_end(); ++s ) {
 					if( UsingShadowDecl *us = dyn_cast<UsingShadowDecl>(*s) ) {
 						if( FieldDecl *f = dyn_cast<FieldDecl>(us->getTargetDecl()) ) {
+							auto config = Config::get();
+							if ( config.is_field_skipping_requested(f->getQualifiedNameAsString())) {
+								continue;
+							}
 							if( is_bindable(f) ) c += "\tcl" + bind_data_member(f, class_qualified_name(C)) + ";\n";
 						}
 					}
@@ -571,6 +575,10 @@ string binding_public_data_members(CXXRecordDecl const *C)
 	for( auto d = C->decls_begin(); d != C->decls_end(); ++d ) {
 		if( FieldDecl *f = dyn_cast<FieldDecl>(*d) ) {
 			//outs() << "Class: " << class_qualified_name(C); f->dump(); outs() << "\n";
+			auto config = Config::get();
+			if ( config.is_field_skipping_requested(f->getQualifiedNameAsString()) ) {
+				continue;
+			}
 			if( f->getAccess() == AS_public and is_bindable(f) ) c += "\tcl" + bind_data_member(f, class_qualified_name(C)) + ";\n";
 		}
 	}

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -57,6 +57,7 @@ void Config::read(string const &file_name)
 	string const _namespace_{"namespace"};
 	string const _function_{"function"};
 	string const _class_{"class"};
+	string const _field_{"field"};
 	string const _enum_{"enum"};
 
 	string const _python_builtin_{"python_builtin"};
@@ -206,6 +207,11 @@ void Config::read(string const &file_name)
 			if( bind ) {
 				auto binder_function = split_in_two(name, "Invalid line for add_on_binder_for_namespace specification! Must be: name_of_type + <space or tab> + name_of_binder. Got: " + line);
 				add_on_binder_for_namespaces_[binder_function.first] = binder_function.second;
+			}
+		} else if ( token == _field_ ) {
+
+			if (!bind) {
+				fields_to_skip.push_back(name_without_spaces);
 			}
 		}
 		else if( token == _custom_shared_ ) holder_type_ = name_without_spaces;
@@ -359,6 +365,19 @@ bool Config::is_class_skipping_requested(string const &class__) const
 		// outs() << "Skipping: " << class_ << "\n";
 		return true;
 	}
+
+	return false;
+}
+
+
+bool Config::is_field_skipping_requested(string const &field_) const
+{
+	string field {field_};
+	field.erase(std::remove(field.begin(), field.end(), ' '), field.end());
+
+	auto bind = std::find(fields_to_skip.begin(), fields_to_skip.end(), field);
+
+	if( bind != fields_to_skip.end() ) return true;
 
 	return false;
 }

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -372,14 +372,7 @@ bool Config::is_class_skipping_requested(string const &class__) const
 
 bool Config::is_field_skipping_requested(string const &field_) const
 {
-	string field {field_};
-	field.erase(std::remove(field.begin(), field.end(), ' '), field.end());
-
-	auto bind = std::find(fields_to_skip.begin(), fields_to_skip.end(), field);
-
-	if( bind != fields_to_skip.end() ) return true;
-
-	return false;
+	return std::find(fields_to_skip.begin(), fields_to_skip.end(), field_) != fields_to_skip.end();
 }
 
 

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -64,7 +64,7 @@ public:
 
 	string root_module;
 
-	std::vector<string> namespaces_to_bind, classes_to_bind, functions_to_bind, namespaces_to_skip, classes_to_skip, functions_to_skip, includes_to_add, includes_to_skip;
+	std::vector<string> namespaces_to_bind, classes_to_bind, functions_to_bind, namespaces_to_skip, classes_to_skip, functions_to_skip, includes_to_add, includes_to_skip, fields_to_skip;
 	std::vector<string> buffer_protocols, module_local_namespaces_to_add, module_local_namespaces_to_skip;
 
 	std::map<string, string> const &binders() const { return binders_; }
@@ -116,6 +116,8 @@ public:
 	string is_custom_trampoline_function_requested(string const &function__) const;
 
 	string includes_code() const;
+
+	bool is_field_skipping_requested(string const &name) const;
 };
 
 

--- a/test/T01.enum.config
+++ b/test/T01.enum.config
@@ -2,3 +2,5 @@
 
 -enum E6_class_not_binded
 +enum aaaa::E7_class
+
+-field A::field1

--- a/test/T01.enum.hpp
+++ b/test/T01.enum.hpp
@@ -26,6 +26,9 @@ public:
 	enum struct AE2_struct { AE3_V0, AE3_V1 };
 	enum class AE3_class { AE2_V0, AE2_V1 };
 
+	int field1 = 0;
+	int field2 = 0;
+
 protected:
 	enum AE3_not_binded { AE3_V0_not_binded, AE3_V1_not_binded };
 	enum class AE4_not_binded { AE4_V0_not_binded, AE4_V1_not_binded };

--- a/test/T01.enum.ref.cpp
+++ b/test/T01.enum.ref.cpp
@@ -61,6 +61,7 @@ void bind_T01_enum(std::function< pybind11::module &(std::string const &namespac
 			.value("AE2_V0", A::AE3_class::AE2_V0)
 			.value("AE2_V1", A::AE3_class::AE2_V1);
 
+		cl.def_readwrite("field2", &A::field2);
 	}
 }
 
@@ -81,7 +82,7 @@ void bind_T01_enum(std::function< pybind11::module &(std::string const &namespac
 
 void bind_T01_enum_1(std::function< pybind11::module &(std::string const &namespace_) > &M)
 {
-	// aaaa::E7_class file:T01.enum.hpp line:43
+	// aaaa::E7_class file:T01.enum.hpp line:46
 	pybind11::enum_<aaaa::E7_class>(M("aaaa"), "E7_class", "")
 		.value("V0", aaaa::E7_class::V0)
 		.value("V1", aaaa::E7_class::V1);


### PR DESCRIPTION
This commit is based on a larger commit by @charbeljc in https://github.com/RosettaCommons/binder/pull/160 but manually cherry-picking just the "-field" feature.