### PR TITLE
Fix build scripts

### DIFF
--- a/build-and-run-tests.py
+++ b/build-and-run-tests.py
@@ -42,7 +42,7 @@ def main(args):
 
     source_path = os.path.abspath('.')
 
-    if not Options.binder: Options.binder = build.install_llvm_tool('binder', source_path+'/source', source_path + '/build', Options.binder_debug, jobs=Options.jobs, gcc_install_prefix=Options.gcc_install_prefix)
+    if not Options.binder: Options.binder = build.install_llvm_tool('binder', source_path+'/source', source_path + '/build', Options.binder_debug, jobs=Options.jobs, gcc_install_prefix=Options.gcc_install_prefix, compiler=Options.compiler)
 
     if not Options.pybind11: Options.pybind11 = build.install_pybind11(source_path + '/build')
 

--- a/build.py
+++ b/build.py
@@ -81,10 +81,10 @@ def get_compiler_family():
     return 'unknown'
 
 
-def get_cmake_compiler_options():
+def get_cmake_compiler_options(compiler):
     ''' Get cmake compiler flags from Options.compiler '''
-    if Platform == "linux" and Options.compiler == 'clang': return ' -DCMAKE_C_COMPILER=`which clang` -DCMAKE_CXX_COMPILER=`which clang++`'
-    if Platform == "linux" and Options.compiler == 'gcc': return ' -DCMAKE_C_COMPILER=`which gcc` -DCMAKE_CXX_COMPILER=`which g++`'
+    if Platform == "linux" and compiler == 'clang': return ' -DCMAKE_C_COMPILER=`which clang` -DCMAKE_CXX_COMPILER=`which clang++`'
+    if Platform == "linux" and compiler == 'gcc': return ' -DCMAKE_C_COMPILER=`which gcc` -DCMAKE_CXX_COMPILER=`which g++`'
 
     return ''
 
@@ -175,7 +175,7 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
             with open(cmake_lists, 'w') as f: f.write(tool_build_line + '\n')
 
         config = '-DCMAKE_BUILD_TYPE={build_type}'.format(build_type='Debug' if debug else 'Release')
-        config += get_cmake_compiler_options()
+        config += get_cmake_compiler_options(compiler)
 
         if not os.path.isdir(build_dir): os.makedirs(build_dir)
         execute(


### PR DESCRIPTION
- fix missing parameter `compiler` in call to `build.install_llvm_tool` from `build-and-run-tests.py` (Issue #266)
- add parameter `compiler` to `build.get_cmake_compiler_options`. This  is needed since if the script is imported, then Options is not in global scope.