### PR TITLE
.clang-format: Remove duplicate key

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,6 @@ ColumnLimit:     200
 MaxEmptyLinesToKeep: 4
 
 AlignTrailingComments: false
-AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
 
 # require clang-format v14+


### PR DESCRIPTION
This makes CLion choke when trying to format