### PR TITLE
Fix Python finding 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,14 @@ set(USE_EXTERNAL_LLVM ON)
 include("GNUInstallDirs")
 set(LLVM_DIR_ORIG ${LLVM_DIR})
 set(Clang_DIR_ORIG ${Clang_DIR})
-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${CMAKE_MODULE_PATH})
+# cmake version >= 3.19 includes all our modules
+if(${CMAKE_VERSION} VERSION_LESS "3.19")
+  set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${CMAKE_MODULE_PATH})
+else()
+  # set CMP0054 to NEW
+  # https://cmake.org/cmake/help/latest/policy/CMP0054.html
+  cmake_policy(SET CMP0054 NEW)
+endif()
 SET(CMAKE_MODULE_PATH_ORIG "${CMAKE_MODULE_PATH}")
 set (CMAKE_MODULE_PATH "${LLVM_DIR};${Clang_DIR};${CMAKE_MODULE_PATH}")
 option(BINDER_ENABLE_TEST      "Enables building of tests" ON)

--- a/cmake/Modules/FindPython/Support.cmake
+++ b/cmake/Modules/FindPython/Support.cmake
@@ -259,7 +259,7 @@ if ("Interpreter" IN_LIST ${_PYTHON_PREFIX}_FIND_COMPONENTS)
   # try more generic names
   if (NOT ${_PYTHON_PREFIX}_EXECUTABLE)
     find_program (${_PYTHON_PREFIX}_EXECUTABLE
-                  NAMES python${${_PYTHON_PREFIX}_VERSION_MAJOR} python
+                  NAMES python${${_PYTHON_PREFIX}_REQUIRED_VERSION_MAJOR} python
                         ${_${_PYTHON_PREFIX}_IRON_PYTHON_NAMES}
                   HINTS ${_${_PYTHON_PREFIX}_HINTS}
                   PATH_SUFFIXES bin)


### PR DESCRIPTION
The current `FindPython3.cmake` had a bug in which it failed to find simplified python exes, like `python3`.

Additionally, it was not very good at dealing with systems that had numerous python installations to choose from, like my own; `cmake` >= 3.19 has `FindPython3`, and all the other cmake Modules that you currently have. So, I changed Cmakelists.txt to only include the modules if the cmake version is < 3.19.