### PR TITLE
Fix external operators in limitations documentation

### DIFF
--- a/documentation/limitations.rst
+++ b/documentation/limitations.rst
@@ -13,6 +13,7 @@ In line with this, ``binder`` will only bind (most) C++ operators if they are me
 These operators include, but are not necessarily limited to:
 
 .. code-block:: console
+
     operator~ (__invert__)
 
     operator+ (__add__)


### PR DESCRIPTION
The supported [external operators](https://cppbinder.readthedocs.io/en/latest/limitations.html#external-operators) are ignored in the documentation because a blank line is missing the `code-block` directive.
![image](https://github.com/RosettaCommons/binder/assets/47051427/b2f8fdd8-8b08-4f5b-8d77-eca915545127)
