### PR TITLE
Add explicit readthedocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,8 +11,7 @@ build:
 sphinx:
   configuration: documentation/conf.py
 
-formats:
-  - all
+formats: all
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "2.7"
+
+sphinx:
+  configuration: documentation/conf.py
+
+formats:
+  - all
+
+python:
+  install:
+    - requirements: documentation/requirements.txt

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -7,3 +7,4 @@ sphinx<2
 sphinx-rtd-theme<0.5
 readthedocs-sphinx-ext<2.3
 jinja2<3.1.0
+

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,0 +1,9 @@
+pillow
+mock==1.0.1
+alabaster>=0.7,<0.8,!=0.7.5
+commonmark==0.9.1
+recommonmark==0.5.0
+sphinx<2
+sphinx-rtd-theme<0.5
+readthedocs-sphinx-ext<2.3
+jinja2<3.1.0

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -7,4 +7,3 @@ sphinx<2
 sphinx-rtd-theme<0.5
 readthedocs-sphinx-ext<2.3
 jinja2<3.1.0
-


### PR DESCRIPTION
ReadTheDocs has required an explicit configuration file since a few months ago, see https://docs.readthedocs.io/en/stable/config-file/, and the latest [builds](https://readthedocs.org/projects/cppbinder/builds/) failed because of this. this pull request introduces the configuration file from the log history of the last successful build.