### PR TITLE
Add a command-line option to print binder version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ set(USE_EXTERNAL_LLVM ON)
 include("GNUInstallDirs")
 set(LLVM_DIR_ORIG ${LLVM_DIR})
 set(Clang_DIR_ORIG ${Clang_DIR})
-add_definitions(-DBINDER_VERSION_STRING=\"${VERSION}\")
 # cmake version >= 3.19 includes all our modules
 if(${CMAKE_VERSION} VERSION_LESS "3.19")
   set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${CMAKE_MODULE_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #This file can be used to build binder using preinstalled LLVM/Clang
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.0)
 PROJECT(binder CXX C)
-SET(VERSION 1.0.0)
+SET(VERSION 1.3.1)
 option(STATIC "Statically compile Binder. See `documentation/install.rst` for more information." OFF)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 #So far there are exceptions in config.cpp
@@ -10,6 +10,7 @@ set(USE_EXTERNAL_LLVM ON)
 include("GNUInstallDirs")
 set(LLVM_DIR_ORIG ${LLVM_DIR})
 set(Clang_DIR_ORIG ${Clang_DIR})
+add_definitions(-DBINDER_VERSION_STRING=\"${VERSION}\")
 # cmake version >= 3.19 includes all our modules
 if(${CMAKE_VERSION} VERSION_LESS "3.19")
   set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${CMAKE_MODULE_PATH})

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -40,6 +40,9 @@ add_clang_executable(binder
   fmt/os.cc
   fmt/os.h
   )
+if (NOT VERSION)
+  set(VERSION 1.4.1)
+endif()  
 target_compile_definitions(binder PUBLIC BINDER_VERSION_STRING=\"${VERSION}\")
 if(USE_EXTERNAL_LLVM)
   if(STATIC)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -40,6 +40,7 @@ add_clang_executable(binder
   fmt/os.cc
   fmt/os.h
   )
+target_compile_definitions(binder PUBLIC BINDER_VERSION_STRING=\"${VERSION}\")
 if(USE_EXTERNAL_LLVM)
   if(STATIC)
     find_library(lib_llvm_path NAMES libclang_static_bundled.a

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -223,6 +223,7 @@ public:
 
 int main(int argc, const char **argv)
 {
+	llvm::cl::SetVersionPrinter([](llvm::raw_ostream &OS) { OS << "binder " << BINDER_VERSION_STRING << "\nLLVM " << LLVM_VERSION_MAJOR << "." << LLVM_VERSION_MINOR << "." << LLVM_VERSION_PATCH << "\n"; });
 #if( LLVM_VERSION_MAJOR < 13 )
 	CommonOptionsParser op(argc, argv, BinderToolCategory);
 	ClangTool tool(op.getCompilations(), op.getSourcePathList());


### PR DESCRIPTION
Add a command-line option to print binder version.
`binder --version`` will display now
```
binder 1.4.1
LLVM 17.0.6
```