### PR TITLE
Implement skip-line-number option

### DIFF
--- a/documentation/config.rst
+++ b/documentation/config.rst
@@ -33,9 +33,9 @@ files. Typically the following files will be generated: ``<root-module>.cpp``, `
 
 ``--flat`` if specified instruct Binder to write generate code files into single directory. Generated files will be named as ``<root-module>.cpp``, ``<root-module>_1.cpp``, ``<root-module>_2.cpp``, ... etc.
 
+``--skip-line-number`` if specified prevents Binder from writing the line numbers in the comments to the generated code.
 
 ``--bind-class-template-specialization`` specify if class-template-specialization should be bound by-default
-
 
 ``--suppress-errors`` if the generated bindings codes are correct but there are some fatal errors from clang and you want to get rid of them. This situation can happen when you would like to generate binding codes for a small part of a huge project and the you cannot include all the required header files with ``-I`` to the command.
 

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -32,8 +32,8 @@ class Config
 
 	Config() {}
 
-	Config(string const &root_module_, std::vector<string> namespaces_to_bind_, std::vector<string> namespaces_to_skip_, string const &prefix_, std::size_t maximum_file_length_)
-		: root_module(root_module_), namespaces_to_bind(namespaces_to_bind_), namespaces_to_skip(namespaces_to_skip_), prefix(prefix_), maximum_file_length(maximum_file_length_)
+	Config(string const &root_module_, std::vector<string> namespaces_to_bind_, std::vector<string> namespaces_to_skip_, string const &prefix_, std::size_t maximum_file_length_, bool skip_line_number_)
+		: root_module(root_module_), namespaces_to_bind(namespaces_to_bind_), namespaces_to_skip(namespaces_to_skip_), prefix(prefix_), maximum_file_length(maximum_file_length_), skip_line_number(skip_line_number_)
 	{
 	}
 
@@ -96,6 +96,8 @@ public:
 	string prefix;
 
 	std::size_t maximum_file_length;
+
+	bool skip_line_number = false;
 
 	/// check if user requested binding for given declaration
 	bool is_namespace_binding_requested(string const &namespace_) const;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -88,6 +88,7 @@ public:
 		config.root_module = O_root_module;
 		config.prefix = O_prefix;
 		config.maximum_file_length = O_max_file_size;
+		config.skip_line_number = O_skip_line_number;
 
 		config.namespaces_to_bind = O_bind;
 		config.namespaces_to_skip = O_skip;

--- a/source/options.cpp
+++ b/source/options.cpp
@@ -38,6 +38,8 @@ cl::opt<std::string> O_root_module("root-module", cl::desc("Name of root module"
 
 cl::opt<int> O_max_file_size("max-file-size", cl::desc("Specify maximum length of generated source files"), cl::init(1024 * 16), cl::cat(BinderToolCategory));
 
+cl::opt<bool> O_skip_line_number("skip-line-number", cl::desc("Do not print line number in the comment to the generated code"), cl::init(false), cl::cat(BinderToolCategory));
+
 cl::opt<std::string> O_prefix("prefix", cl::desc("Output path for all generated files. Specified path must exists."), cl::init(""), cl::cat(BinderToolCategory));
 
 cl::list<std::string> O_bind("bind", cl::desc("Namespace to bind, could be specified more then once. Specify \"\" to bind all namespaces."), cl::cat(BinderToolCategory)); // , cl::OneOrMore

--- a/source/options.hpp
+++ b/source/options.hpp
@@ -28,6 +28,7 @@ extern llvm::cl::opt<bool> O_include_pybind11_stl;
 
 extern llvm::cl::opt<std::string> O_root_module;
 extern llvm::cl::opt<int> O_max_file_size;
+extern llvm::cl::opt<bool> O_skip_line_number;
 extern llvm::cl::opt<std::string> O_prefix;
 extern llvm::cl::list<std::string> O_bind;
 extern llvm::cl::list<std::string> O_skip;

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -255,6 +255,8 @@ string template_argument_to_string(clang::TemplateArgument const &t)
 // calcualte line in source file for NamedDecl
 string line_number(NamedDecl const *decl)
 {
+	bool l_skip_line_number = Config::get().skip_line_number;
+	if (l_skip_line_number) return std::string("");
 	ASTContext &ast_context(decl->getASTContext());
 	SourceManager &sm(ast_context.getSourceManager());
 


### PR DESCRIPTION
Implementation of an option to skip line numbers in the comments to the generated code.

This option is useful for the following use case:
 - the bindings are stored in e.g. git repository and are regenerated from time to time

In this scenario, the input headers might be updated, e.g. the new functions can be added without the updates of the signatures of the binded functions. As a result, if one reruns the binder, the only update of the binded code might be the changes in the line numbers.

To avoid this situation one can remove the line numbers from the comments to the code.

