### PR TITLE
Update util.cpp to avoid compiler warning and  trow an error if a directory cannot be created.

### DIFF
--- a/source/util.cpp
+++ b/source/util.cpp
@@ -135,7 +135,7 @@ void update_source_file(std::string const &prefix, std::string const &file_name,
 
 	// std::experimental::filesystem::create_directories(path);
 	string command_line = "mkdir -p " + path;
-	if (system(command_line.c_str() != 0) throw std::runtime_error("ERROR: Command \"" + command_line + "\" failed");
+	if (system(command_line.c_str()) != 0) throw std::runtime_error("ERROR: Command \"" + command_line + "\" failed");
 
 	string full_file_name = prefix + '/' + file_name;
 	std::ifstream f(full_file_name);

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -135,7 +135,7 @@ void update_source_file(std::string const &prefix, std::string const &file_name,
 
 	// std::experimental::filesystem::create_directories(path);
 	string command_line = "mkdir -p " + path;
-	system(command_line.c_str());
+	if (system(command_line.c_str() != 0) throw std::runtime_error("ERROR: Command \"" + command_line + "\" failed");
 
 	string full_file_name = prefix + '/' + file_name;
 	std::ifstream f(full_file_name);


### PR DESCRIPTION
Update util.cpp to avoid compiler warning 
```
/source/util.cpp:138:15: warning: ignoring return value of 'int system(const char*)' declared with attribute 'warn_unused_result' [-Wunused-result]
  138 |         system(command_line.c_str());
```

and  trow an error if a directory cannot be created.