### PR TITLE
Update class.cpp to avoid compiler warnings

### DIFF
--- a/source/class.cpp
+++ b/source/class.cpp
@@ -662,27 +662,6 @@ bool is_callback_structure_constructible(CXXRecordDecl const *C)
 	return true;
 }
 
-
-// call_back_function_body_template is almost like PYBIND11_OVERLOAD_INT but specify pybind11::return_value_policy::reference
-// #define PYBIND11_OVERLOAD_INT(ret_type, cname, name, ...) { \
-//         pybind11::gil_scoped_acquire gil; \
-//         pybind11::function overload = pybind11::get_overload(static_cast<const cname *>(this), name); \
-//         if (overload) \
-//             return overload(__VA_ARGS__).template cast<ret_type>();  }
-//
-// 		pybind11::gil_scoped_acquire gil; \
-// 		pybind11::function overload = pybind11::get_overload(static_cast<const cname *>(this), name); \
-// 		if (overload) { \
-// 			auto o = overload(__VA_ARGS__); \
-// 			if (pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) { \
-// 				static pybind11::detail::overload_caster_t<ret_type> caster; \
-// 				return pybind11::detail::cast_ref<ret_type>(std::move(o), caster); \
-// 			} \
-// 			else return pybind11::detail::cast_safe<ret_type>(std::move(o)); \
-// 		} \
-// 	}
-
-
 const char *call_back_function_body_template = R"_(
 pybind11::gil_scoped_acquire gil;
 pybind11::function overload = pybind11::get_overload(static_cast<const {0} *>(this), "{1}");


### PR DESCRIPTION
Update class.cpp to avoid compiler warnings

```
source/class.cpp:667:1: warning: multi-line comment [-Wcomment]
  667 | // #define PYBIND11_OVERLOAD_INT(ret_type, cname, name, ...) { \
      | ^
```