### PR TITLE
Persist container ARGs across multiple stages

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,8 +1,11 @@
-FROM ubuntu:20.04 as base
-
 # Config
 ARG BRANCH="master"
 ARG CLANG_VERSION=14
+
+
+FROM ubuntu:20.04 as base
+ARG BRANCH
+ARG CLANG_VERSION
 
 # General dependencies
 ENV DEBIAN_FRONTEND=noninteractive
@@ -22,6 +25,8 @@ RUN apt-get update \
 
 # Build binder
 FROM base as build
+ARG BRANCH
+ARG CLANG_VERSION
 
 # Build dependencies
 RUN apt-get update


### PR DESCRIPTION
The behavior of ARG in multi-stage Dockerfiles is a bit unusual. They are scoped to each stage, so you have to repeat them if you want to use the same variable in multiple stages. *But*, if you set a default value, that default value has to be set before the first stage. [Ref. StackOverflow answer.](https://stackoverflow.com/a/53682110)

The container does not actually build without this change, because the `${CLANG_VERSION}` variable expands to the empty string in the second stage, and then it fails installing `clang--dev`.