### PR TITLE
Update context.cpp to comply with pybind11 2.0+ docs

### DIFF
--- a/source/context.cpp
+++ b/source/context.cpp
@@ -132,7 +132,7 @@ const char *module_header = R"_(
 #ifndef BINDER_PYBIND11_TYPE_CASTER
 	#define BINDER_PYBIND11_TYPE_CASTER
 	{2}
-	PYBIND11_DECLARE_HOLDER_TYPE(T, T*)
+	PYBIND11_DECLARE_HOLDER_TYPE(T, T*, false)
 	{3}
 #endif
 
@@ -437,7 +437,7 @@ void Context::generate(Config const &config)
 
 		string const holder_type = Config::get().holder_type();
 
-		string shared_declare = "PYBIND11_DECLARE_HOLDER_TYPE(T, "+holder_type+"<T>)";
+		string shared_declare = "PYBIND11_DECLARE_HOLDER_TYPE(T, "+holder_type+"<T>, false)";
 		string shared_make_opaque = "PYBIND11_MAKE_OPAQUE("+holder_type+"<void>)";
 
 		string const pybind11_include = "#include <" + Config::get().pybind11_include_file() + ">";


### PR DESCRIPTION
Update context.cpp to comply with pybind11 2.0+ docs, i.e.
PYBIND11_DECLARE_HOLDER_TYPE from version 2.0 requires at least 3 arguments otherwise the compillers will issue warnings.
See https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html
```
The first argument of PYBIND11_DECLARE_HOLDER_TYPE() should be a placeholder name that is used as a template parameter of the second argument. Thus, feel free to use any identifier, but use it consistently on both sides; also, don’t use the name of a type that already exists in your codebase.

The macro also accepts a third optional boolean parameter that is set to false by default. 
```
