### PR TITLE
Fix MSVC error on unknown identifier uint in `function.hpp`

### DIFF
--- a/source/function.hpp
+++ b/source/function.hpp
@@ -14,6 +14,7 @@
 #define _INCLUDED_function_hpp_
 
 #include <binder.hpp>
+#include <config.hpp>
 
 #include <clang/AST/Decl.h>
 #include <clang/AST/DeclCXX.h>


### PR DESCRIPTION
I found this error when trying to build `binder` with MSVC. Relates to #20, #59.