### PR TITLE
Do not check type dependencies when determine if bindings should be skipped

### DIFF
--- a/source/class.cpp
+++ b/source/class.cpp
@@ -340,7 +340,8 @@ bool is_binding_requested(clang::CXXRecordDecl const *C, Config const &config)
 	if( (not bind_class_template_specialization) and dyn_cast<ClassTemplateSpecializationDecl>(C) ) return false;
 
 	bool bind = config.is_namespace_binding_requested(namespace_from_named_decl(C));
-	for( auto &t : get_type_dependencies(C) ) bind &= !is_skipping_requested(t, config);
+	// Do not check type dependencies when checking if binding is requested
+	// for( auto &t : get_type_dependencies(C) ) bind &= !is_skipping_requested(t, config);
 	return bind;
 }
 
@@ -358,7 +359,8 @@ bool is_skipping_requested(clang::CXXRecordDecl const *C, Config const &config)
 
 	bool skip = config.is_namespace_skipping_requested(namespace_from_named_decl(C));
 
-	for( auto &t : get_type_dependencies(C) ) skip |= is_skipping_requested(t, config);
+	// Do not check type dependencies when checking if binding is requested
+	// for( auto &t : get_type_dependencies(C) ) skip |= is_skipping_requested(t, config);
 
 	return skip;
 }

--- a/source/function.cpp
+++ b/source/function.cpp
@@ -318,7 +318,8 @@ bool is_binding_requested(FunctionDecl const *F, Config const &config)
 
 	bool bind = config.is_namespace_binding_requested(namespace_from_named_decl(F));
 
-	for( auto &t : get_type_dependencies(F) ) bind |= binder::is_binding_requested(t, config);
+	// Do not check type dependencies when checking if binding is requested
+	// for( auto &t : get_type_dependencies(F) ) bind |= binder::is_binding_requested(t, config);
 
 	return bind;
 }
@@ -353,7 +354,8 @@ bool is_skipping_requested(FunctionDecl const *F, Config const &config)
 	}
 	// outs() << "OK\n";
 
-	for( auto &t : get_type_dependencies(F) ) skip |= is_skipping_requested(t, config);
+	// Do not check type dependencies when checking if binding is requested
+	// for( auto &t : get_type_dependencies(F) ) skip |= is_skipping_requested(t, config);
 
 	return skip;
 }


### PR DESCRIPTION
## Description

I am using binder to generate bindings for functions/methods that take Eigen matrices as arguments or return values. For example:

```c++
#include <Eigen/Dense>

void eigen_argument_function(const Eigen::Matrix<T, 3, 3> &m) {};
```

I don't want to bind the whole Eigen library, thus I have to exclude the `Eigen` namespace for binder:
```
- namespace Eigen
```

However, the bindings of functions/methods that take Eigen matrices as arguments or return values do not generate because these functions/methods depend on the eigen library and thus skipped. Bindings of any functions/methods that have dependencies of excluded namespaces will not be generated, and this is not what I wanted.

In my own understanding, when I exclude a namespace, I mean I only want to exclude classes/functions in that namespace, but not classes/functions that have dependencies on that namespace.

In addition, I found that when generating bindings for enums, the dependencies will not be checked:
https://github.com/RosettaCommons/binder/blob/7d6ec91db99d5f049db7dd8aea186a4c74f6742f/source/enum.cpp#L59-L67
https://github.com/RosettaCommons/binder/blob/7d6ec91db99d5f049db7dd8aea186a4c74f6742f/source/enum.cpp#L69-L82

If this change is not appropriate, maybe adding a configuration option would be helpful.
