### PR TITLE
Remove import of removed, unused Python modules

### DIFF
--- a/build.py
+++ b/build.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-import os, sys, argparse, platform, subprocess, shutil, distutils.dir_util, json
+import os, sys, argparse, platform, subprocess, shutil, json
 
 from collections import OrderedDict
 

--- a/build.py
+++ b/build.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-import os, sys, argparse, platform, subprocess, imp, shutil, distutils.dir_util, json
+import os, sys, argparse, platform, subprocess, shutil, distutils.dir_util, json
 
 from collections import OrderedDict
 


### PR DESCRIPTION
Python 3.12 doesn't have `imp`, and this file doesn't seem to actually use it.