### PR TITLE
Support Ubuntu 24.04 and LLVM 14.0.5; automatically select LLVM version based on compiler version

### DIFF
--- a/build-and-run-tests.py
+++ b/build-and-run-tests.py
@@ -33,6 +33,7 @@ def main(args):
     parser.add_argument('--binder', default='', help='Path to Binder tool. If none is given then download, build and install binder into main/source/build. Use "--binder-debug" to control which mode of binder (debug/release) is used.')
     parser.add_argument("--binder-debug", action="store_true", help="Run binder tool in debug mode (only relevant if no '--binder' option was specified)")
     parser.add_argument('--pybind11', default='', help='Path to pybind11 source tree')
+    parser.add_argument('--llvm-version', default=None, choices=['6.0.1', '13.0.0'], help='Manually specify LLVM version to install')
     parser.add_argument('--annotate-includes', action="store_true", help='Annotate includes in generated source files')
     parser.add_argument('--trace', action="store_true", help='Binder will add trace output to to generated source files')
     parser.add_argument('--gcc-install-prefix', default=None, help='Path to GCC install prefix which will be used to determent location of libstdc++ for Binder build. Default is: auto-detected. Use this option if you would like to build Binder with compiler that was side-installed and which LLVM build system failed to identify. To see what path Binder uses for libstdc++ run `binder -- -xc++ -E -v`.')
@@ -42,7 +43,7 @@ def main(args):
 
     source_path = os.path.abspath('.')
 
-    if not Options.binder: Options.binder = build.install_llvm_tool('binder', source_path+'/source', source_path + '/build', Options.binder_debug, jobs=Options.jobs, gcc_install_prefix=Options.gcc_install_prefix, compiler=Options.compiler)
+    if not Options.binder: Options.binder = build.install_llvm_tool('binder', source_path+'/source', source_path + '/build', Options.binder_debug, jobs=Options.jobs, gcc_install_prefix=Options.gcc_install_prefix, compiler=Options.compiler, llvm_version=Options.llvm_version)
 
     if not Options.pybind11: Options.pybind11 = build.install_pybind11(source_path + '/build')
 

--- a/build-and-run-tests.py
+++ b/build-and-run-tests.py
@@ -33,7 +33,7 @@ def main(args):
     parser.add_argument('--binder', default='', help='Path to Binder tool. If none is given then download, build and install binder into main/source/build. Use "--binder-debug" to control which mode of binder (debug/release) is used.')
     parser.add_argument("--binder-debug", action="store_true", help="Run binder tool in debug mode (only relevant if no '--binder' option was specified)")
     parser.add_argument('--pybind11', default='', help='Path to pybind11 source tree')
-    parser.add_argument('--llvm-version', default=None, choices=['6.0.1', '13.0.0'], help='Manually specify LLVM version to install')
+    parser.add_argument('--llvm-version', default=None, choices=['6.0.1', '13.0.0', '14.0.5'], help='Manually specify LLVM version to install')
     parser.add_argument('--annotate-includes', action="store_true", help='Annotate includes in generated source files')
     parser.add_argument('--trace', action="store_true", help='Binder will add trace output to to generated source files')
     parser.add_argument('--gcc-install-prefix', default=None, help='Path to GCC install prefix which will be used to determent location of libstdc++ for Binder build. Default is: auto-detected. Use this option if you would like to build Binder with compiler that was side-installed and which LLVM build system failed to identify. To see what path Binder uses for libstdc++ run `binder -- -xc++ -E -v`.')

--- a/build.py
+++ b/build.py
@@ -226,7 +226,7 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
         if not os.path.isdir(build_dir): os.makedirs(build_dir)
         execute(
             'Building tool: {}...'.format(name), # -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=1
-            'cd {build_dir} && cmake -G Ninja {config} -DLLVM_ENABLE_EH=1 -DLLVM_ENABLE_RTTI=ON {gcc_install_prefix} .. && ninja binder {headers} {jobs}'.format( # was 'binder clang', we need to build Clang so lib/clang/<version>/include is also built
+            'cd {build_dir} && cmake -G Ninja {config} -DLLVM_ENABLE_EH=1 -DLLVM_ENABLE_RTTI=ON -DLLVM_INCLUDE_BENCHMARKS=OFF {gcc_install_prefix} .. && ninja binder {headers} {jobs}'.format( # was 'binder clang', we need to build Clang so lib/clang/<version>/include is also built
                 build_dir=build_dir, config=config,
                 jobs=f'-j{jobs}' if jobs else '',
                 gcc_install_prefix='-DGCC_INSTALL_PREFIX='+gcc_install_prefix if gcc_install_prefix else '',

--- a/build.py
+++ b/build.py
@@ -177,7 +177,7 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
             if os.path.isdir(prefix): shutil.rmtree(prefix)
             execute('Download LLVM source...', 'cd {prefix_root} && curl -LJ {llvm_url} | tar -Jxom && mv llvm-{llvm_version}.src {prefix}'.format(**locals()) )
             os.makedirs(cmake_path, exist_ok=True)
-            open(cmake_version_path).write(llvm_version)
+            open(cmake_version_path, 'w').write(llvm_version)
 
         if not os.path.isdir(clang_path):
             #execute('Download Clang source...', 'cd {prefix_root} && curl https://releases.llvm.org/{llvm_version}/cfe-{llvm_version}.src.tar.xz | tar -Jxom && mv cfe-{llvm_version}.src {clang_path}'.format(**locals()) )

--- a/build.py
+++ b/build.py
@@ -276,7 +276,7 @@ def main(args):
     parser.add_argument('--binder', default='', help='Path to Binder tool. If none is given then download, build and install binder into build/ directory. Use "--binder-debug" to control which mode of binder (debug/release) is used.')
     parser.add_argument("--binder-debug", action="store_true", help="Run binder tool in debug mode (only relevant if no '--binder' option was specified)")
     parser.add_argument('--pybind11', default='', help='Path to pybind11 source tree')
-    parser.add_argument('--llvm-version', default=None, choices=['6.0.1', '13.0.0'], help='Manually specify LLVM version to install')
+    parser.add_argument('--llvm-version', default=None, choices=['6.0.1', '13.0.0', '14.0.5'], help='Manually specify LLVM version to install')
     parser.add_argument('--annotate-includes', action="store_true", help='Annotate includes in generated source files')
     parser.add_argument('--trace', action="store_true", help='Binder will add trace output to to generated source files')
 

--- a/build.py
+++ b/build.py
@@ -166,13 +166,16 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
             '14.0.5' : ('https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.5/llvm-14.0.5.src.tar.xz', 'https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.5/clang-14.0.5.src.tar.xz')
         }[llvm_version]
 
+        # The LLVM tarballs may include a "cmake" directory that needs to be sibling to the main source directories in order for the build to work.
+
         if not os.path.isfile(prefix + '/CMakeLists.txt'):
             #execute('Download LLVM source...', 'cd {prefix_root} && curl https://releases.llvm.org/{llvm_version}/llvm-{llvm_version}.src.tar.xz | tar -Jxom && mv llvm-{llvm_version}.src {prefix}'.format(**locals()) )
-            execute('Download LLVM source...', 'cd {prefix_root} && mkdir llvm-{llvm_version}.src && curl -LJ {llvm_url} | tar --strip-components=1 -Jxom -C llvm-{llvm_version}.src && mv llvm-{llvm_version}.src {prefix}'.format(**locals()) )
+            execute('Download LLVM source...', 'cd {prefix_root} && curl -LJ {llvm_url} | tar -Jxom && mv llvm-{llvm_version}.src {prefix}'.format(**locals()) )
 
         if not os.path.isdir(clang_path):
             #execute('Download Clang source...', 'cd {prefix_root} && curl https://releases.llvm.org/{llvm_version}/cfe-{llvm_version}.src.tar.xz | tar -Jxom && mv cfe-{llvm_version}.src {clang_path}'.format(**locals()) )
-            execute('Download Clang source...', 'cd {prefix_root} && mkdir clang-{llvm_version}.src && curl -LJ {clang_url} | tar --strip-components=1 -Jxom -C clang-{llvm_version}.src && mv clang-{llvm_version}.src {clang_path}'.format(**locals()) )
+            clang_name = 'cfe' if llvm_version == '6.0.1' else 'clang'
+            execute('Download Clang source...', 'cd {prefix_root} && curl -LJ {clang_url} | tar -Jxom && mv {clang_name}-{llvm_version}.src {clang_path}'.format(**locals()) )
 
         if not os.path.isdir(prefix+'/tools/clang/tools/extra'): os.makedirs(prefix+'/tools/clang/tools/extra')
 

--- a/build.py
+++ b/build.py
@@ -166,7 +166,15 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
             '14.0.5' : ('https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.5/llvm-14.0.5.src.tar.xz', 'https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.5/clang-14.0.5.src.tar.xz')
         }[llvm_version]
 
-        # The LLVM tarballs may include a "cmake" directory that needs to be sibling to the main source directories in order for the build to work.
+        # The LLVM tarballs may include a "cmake" directory that needs to be
+        # sibling to the main source directories in order for the build to
+        # work.
+        
+        # TODO: That path can't depend on the LLVM version. If we really need
+        # to keep those files straight while switching between multiple LLVM
+        # versions, we need a separate root build directory per LLVM version,
+        # and we need to adjust the path at which we expect to find the build
+        # results!
 
         if not os.path.isfile(prefix + '/CMakeLists.txt'):
             #execute('Download LLVM source...', 'cd {prefix_root} && curl https://releases.llvm.org/{llvm_version}/llvm-{llvm_version}.src.tar.xz | tar -Jxom && mv llvm-{llvm_version}.src {prefix}'.format(**locals()) )

--- a/build.py
+++ b/build.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-import os, sys, argparse, platform, subprocess, shutil, distutils.dir_util, json
+import os, sys, argparse, platform, subprocess, shutil, json
 
 from collections import OrderedDict
 

--- a/build.py
+++ b/build.py
@@ -110,12 +110,16 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
         # Clang-3.4. So we need to dynamicly change LLVM version based on
         # complier versions
 
-        if ((compiler == 'gcc' and compiler_version > 11) or
-            (Platform == 'macos' and platform.machine() == 'arm64')):
+        if compiler == 'gcc' and compiler_version >= 13:
             # GCC13's STL no longer works with LLVM 6, it has features that
             # require e.g.
             # <https://github.com/llvm/llvm-project/commit/add16a8da9ccd07eabda2dffd0d32188f07da09c>
             # released in LLVM 9.
+            # Also, LLVM 13 has a bug with not actually including the headers it
+            # needs <https://github.com/llvm/llvm-project/issues/55711>, which
+            # wasn't fixed until 14.0.5.
+            llvm_version = '14.0.5'
+        elif Platform == 'macos' and platform.machine() == 'arm64':
             # ARM Mac also requires a newer LLVM version
             llvm_version = '13.0.0'
         else:
@@ -124,6 +128,7 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
             llvm_version = '6.0.1'
 
     headers = {
+        '14.0.5': 'tools/clang/lib/Headers/clang-resource-headers',
         '13.0.0': 'tools/clang/lib/Headers/clang-resource-headers',
         '6.0.1': 'tools/clang/lib/Headers/clang-headers'
     }[llvm_version]
@@ -158,6 +163,7 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
         llvm_url, clang_url = {
             '6.0.1'  : ('https://releases.llvm.org/6.0.1/llvm-6.0.1.src.tar.xz', 'https://releases.llvm.org/6.0.1/cfe-6.0.1.src.tar.xz'),
             '13.0.0' : ('https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/llvm-13.0.0.src.tar.xz', 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang-13.0.0.src.tar.xz'),
+            '14.0.5' : ('https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.5/llvm-14.0.5.src.tar.xz', 'https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.5/clang-14.0.5.src.tar.xz')
         }[llvm_version]
 
         if not os.path.isfile(prefix + '/CMakeLists.txt'):

--- a/build.py
+++ b/build.py
@@ -168,13 +168,9 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
 
         # The LLVM tarballs may include a "cmake" directory that needs to be
         # sibling to the main source directories in order for the build to
-        # work.
-        
-        # TODO: That path can't depend on the LLVM version. If we really need
-        # to keep those files straight while switching between multiple LLVM
-        # versions, we need a separate root build directory per LLVM version,
-        # and we need to adjust the path at which we expect to find the build
-        # results!
+        # work. That path can't depend on the LLVM version, but it's also only
+        # needed at build time, and we only build when we've just extracted the
+        # tarball. 
 
         if not os.path.isfile(prefix + '/CMakeLists.txt'):
             #execute('Download LLVM source...', 'cd {prefix_root} && curl https://releases.llvm.org/{llvm_version}/llvm-{llvm_version}.src.tar.xz | tar -Jxom && mv llvm-{llvm_version}.src {prefix}'.format(**locals()) )

--- a/build.py
+++ b/build.py
@@ -168,13 +168,16 @@ def install_llvm_tool(name, source_location, prefix_root, debug, compiler, jobs,
 
         # The LLVM tarballs may include a "cmake" directory that needs to be
         # sibling to the main source directories in order for the build to
-        # work. That path can't depend on the LLVM version, but it's also only
-        # needed at build time, and we only build when we've just extracted the
-        # tarball. 
+        # work. That path can't depend on the LLVM version, so we track that ourselves.
+        cmake_path = os.path.join(prefix_root, "cmake")
+        cmake_version_path = os.path.join(cmake_path, "llvm_version.txt")
 
-        if not os.path.isfile(prefix + '/CMakeLists.txt'):
+        if not os.path.isfile(prefix + '/CMakeLists.txt') or not os.path.isfile(cmake_version_path) or open(cmake_version_path).read() != llvm_version:
             #execute('Download LLVM source...', 'cd {prefix_root} && curl https://releases.llvm.org/{llvm_version}/llvm-{llvm_version}.src.tar.xz | tar -Jxom && mv llvm-{llvm_version}.src {prefix}'.format(**locals()) )
+            if os.path.isdir(prefix): shutil.rmtree(prefix)
             execute('Download LLVM source...', 'cd {prefix_root} && curl -LJ {llvm_url} | tar -Jxom && mv llvm-{llvm_version}.src {prefix}'.format(**locals()) )
+            os.makedirs(cmake_path, exist_ok=True)
+            open(cmake_version_path).write(llvm_version)
 
         if not os.path.isdir(clang_path):
             #execute('Download Clang source...', 'cd {prefix_root} && curl https://releases.llvm.org/{llvm_version}/cfe-{llvm_version}.src.tar.xz | tar -Jxom && mv cfe-{llvm_version}.src {clang_path}'.format(**locals()) )

--- a/build.py
+++ b/build.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-import os, sys, argparse, platform, subprocess, imp, shutil, distutils.dir_util, json
+import os, sys, argparse, platform, subprocess, shutil, distutils.dir_util, json
 
 from collections import OrderedDict
 


### PR DESCRIPTION
This PR updates Binder to work on Ubuntu 24.04, with its GCC 13.

It also implements the compiler-version-dependent LLVM version selection logic that the build scripts wanted, and adds an `--llvm-version` command line flag to them to override it.

It includes LLVM 14.0.5, which will be automatically selected for GCC 13 or newer, since it's the oldest LLVM I could find that can build on GCC 13 and understand GCC 13's STL headers.

I had to change how the LLVM tarballs are extracted to not lose the `cmake` directory that LLVM 14.0.5 needs next to its source directory to build. I added some version tracking for this directory, which will involve redownloading LLVM if it needs to change versions.