### PR TITLE
Ensure Binder compatibility with LLVM monorepo structure

### DIFF
--- a/documentation/install.rst
+++ b/documentation/install.rst
@@ -57,7 +57,7 @@ To *statically* compile binder, see :ref:`building-static`.
 
   # Build Binder
   mkdir $HOME/prefix/build && cd $HOME/prefix/build
-  cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_EH=1 -DLLVM_ENABLE_RTTI=ON ../llvm && ninja
+  cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_EH=1 -DLLVM_ENABLE_RTTI=ON ../llvm/llvm && ninja
 
   # At this point, if all above steps is successful, binder should be at
   # $HOME/prefix/build/bin/binder


### PR DESCRIPTION
Included is a update to the llvm path in the final build command. This is necessary because while LLVM 6.0.1 originally used a multi-repo structure, the llvmorg-6.0.1 tag has since been retroactively added to the monorepo. As a result, the build must now target the llvm/ subdirectory inside llvm-project.