### PR TITLE
Fix MacOSX CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
              ctest . --output-on-failure
 
   compilejobOSX:
-    runs-on: macos-latest
+    runs-on: macos-13
     name: Binder_on_OSX
     steps:
     - name: Checkout


### PR DESCRIPTION
`macos-latest` corresponds to the arm64 runners, the "latest" version of the x86 runners is `macos-13`.