### PR TITLE
Run clang-format on all source files

### DIFF
--- a/source/binder.cpp
+++ b/source/binder.cpp
@@ -27,15 +27,15 @@ namespace binder {
 
 bool IncludeSet::add_decl(clang::NamedDecl const *D, int level)
 {
-	auto it_inserted = stack_.insert( {D, level} );
-	auto & it = it_inserted.first;
-	auto & inserted = it_inserted.second;
-	if(inserted) return true;
+	auto it_inserted = stack_.insert({D, level});
+	auto &it = it_inserted.first;
+	auto &inserted = it_inserted.second;
+	if( inserted ) return true;
 	else {
 		if( it->second <= level ) return false;
 		else {
 			it->second = level;
-			//it.value() = level;
+			// it.value() = level;
 			return true;
 		}
 	}

--- a/source/binder.hpp
+++ b/source/binder.hpp
@@ -16,9 +16,9 @@
 #include <clang/AST/Decl.h>
 #include <clang/AST/DeclCXX.h>
 
-#include <llvm/Support/raw_ostream.h>
 #include <llvm/ADT/DenseMap.h>
-//#include <tsl/robin_map.h>
+#include <llvm/Support/raw_ostream.h>
+// #include <tsl/robin_map.h>
 
 #include <string>
 #include <unordered_map>
@@ -48,9 +48,9 @@ public:
 private:
 	std::vector<std::string> includes_;
 
-	//using StackType = std::unordered_map<clang::NamedDecl const *, int>;
+	// using StackType = std::unordered_map<clang::NamedDecl const *, int>;
 	using StackType = llvm::DenseMap<clang::NamedDecl const *, int>;
-	//using StackType = tsl::robin_map<clang::NamedDecl const *, int>;
+	// using StackType = tsl::robin_map<clang::NamedDecl const *, int>;
 
 	StackType stack_;
 
@@ -59,10 +59,18 @@ private:
 
 
 enum RequestFlags : int8_t {
-	none=0, skipping = 1, binding = 2,
+	none = 0,
+	skipping = 1,
+	binding = 2,
 };
-inline RequestFlags operator|(RequestFlags a, RequestFlags b) { return static_cast<RequestFlags>(static_cast<int>(a) | static_cast<int>(b)); }
-inline RequestFlags operator&(RequestFlags a, RequestFlags b) { return static_cast<RequestFlags>(static_cast<int>(a) & static_cast<int>(b)); }
+inline RequestFlags operator|(RequestFlags a, RequestFlags b)
+{
+	return static_cast<RequestFlags>(static_cast<int>(a) | static_cast<int>(b));
+}
+inline RequestFlags operator&(RequestFlags a, RequestFlags b)
+{
+	return static_cast<RequestFlags>(static_cast<int>(a) & static_cast<int>(b));
+}
 
 /// Bindings Generator - represent object that can generate binding info for function, class, enum or data variable
 class Binder
@@ -92,7 +100,7 @@ public:
 
 
 	/// check if user supplied config requested binding for the given declaration and if so request it
-	virtual void request_bindings_and_skipping(Config const &, RequestFlags flags = RequestFlags::skipping | RequestFlags::binding)  = 0;
+	virtual void request_bindings_and_skipping(Config const &, RequestFlags flags = RequestFlags::skipping | RequestFlags::binding) = 0;
 
 	/// extract include needed for this generator and add it to includes vector
 	virtual void add_relevant_includes(IncludeSet &) const = 0;

--- a/source/class.cpp
+++ b/source/class.cpp
@@ -20,7 +20,7 @@
 #include <fmt/format.h>
 
 #include <clang/AST/DeclTemplate.h>
-//#include <clang/AST/TemplateBase.h>
+// #include <clang/AST/TemplateBase.h>
 
 
 using namespace llvm;
@@ -53,8 +53,8 @@ string template_specialization(clang::CXXRecordDecl const *C)
 			// outs() << " template argument: " << template_argument_to_string(t->getTemplateArgs()[i]) << "\n";
 			// templ += template_argument_to_string(t->getTemplateArgs()[i]) + ",";
 			std::string template_arg = template_argument_to_string(t->getTemplateArgs()[i]);
-			if ((template_arg[0] == '<') and (template_arg[template_arg.size()-1]=='>')) template_arg = template_arg.substr(1, template_arg.size()-2);
-			if (template_arg.size()>0) templ += template_arg + ",";
+			if( (template_arg[0] == '<') and (template_arg[template_arg.size() - 1] == '>') ) template_arg = template_arg.substr(1, template_arg.size() - 2);
+			if( template_arg.size() > 0 ) templ += template_arg + ",";
 
 			// if( t->getTemplateArgs()[i].ArgKind() == TemplateArgument::ArgKind::Integral ) outs() << " template arg:" << t->getTemplateArgs()[i].<< "\n";
 			// outs() << expresion_to_string( t->getTemplateArgs()[i].getAsExpr() ) << "\n";
@@ -141,7 +141,7 @@ bool is_bindable(FieldDecl *f)
 {
 	if( f->getType()->isAnyPointerType() or f->getType()->isReferenceType() or f->getType()->isArrayType() ) return false;
 
-	//if( !is_field_assignable(f) ) return false;
+	// if( !is_field_assignable(f) ) return false;
 
 	if( f->isAnonymousStructOrUnion() ) return false;
 
@@ -228,7 +228,7 @@ bool is_bindable(clang::CXXRecordDecl const *C)
 	if( it != cache.end() ) return it->second;
 	else {
 		bool r = is_bindable_raw(C);
-		cache.insert( {C, r} );
+		cache.insert({C, r});
 		return r;
 	}
 
@@ -441,7 +441,7 @@ void add_relevant_includes(clang::CXXRecordDecl const *C, IncludeSet &includes, 
 
 inline void add_includes_to_set(std::vector<std::string> const &from, IncludeSet &to)
 {
-	for(auto const &i : from) to.add_include(i);
+	for( auto const &i : from ) to.add_include(i);
 }
 
 void add_relevant_includes_cached(clang::CXXRecordDecl const *C, IncludeSet &includes)
@@ -523,10 +523,10 @@ bool ClassBinder::bindable() const
 
 
 /// check if user requested binding for the given declaration
-void ClassBinder::request_bindings_and_skipping(Config const & config, RequestFlags flags)
+void ClassBinder::request_bindings_and_skipping(Config const &config, RequestFlags flags)
 {
-	if( (flags&RequestFlags::skipping) and is_skipping_requested(C, config) ) Binder::request_skipping();
-	else if( (flags&RequestFlags::binding) and is_binding_requested(C, config) ) Binder::request_bindings();
+	if( (flags & RequestFlags::skipping) and is_skipping_requested(C, config) ) Binder::request_skipping();
+	else if( (flags & RequestFlags::binding) and is_binding_requested(C, config) ) Binder::request_bindings();
 }
 
 
@@ -549,16 +549,14 @@ void ClassBinder::add_relevant_includes(IncludeSet &includes) const
 	includes.add_include("<sstream> // __str__");
 }
 
-string generate_opaque_declaration_if_needed(string const & qualified_name, string const & qualified_name_without_template)
+string generate_opaque_declaration_if_needed(string const &qualified_name, string const &qualified_name_without_template)
 {
 	// pybind11 container lists https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html
-	static vector<string> stl_containers {"std::vector", "std::deque", "std::list", "std::array", "std::valarray", "std::set", "std::unordered_set", "std::map", "std::unordered_map"};
+	static vector<string> stl_containers{"std::vector", "std::deque", "std::list", "std::array", "std::valarray", "std::set", "std::unordered_set", "std::map", "std::unordered_map"};
 
 	if( begins_with(qualified_name_without_template, "std::") ) {
 		auto it = std::find(stl_containers.begin(), stl_containers.end(), qualified_name_without_template);
-		if( it != stl_containers.end() ) {
-			return "PYBIND11_MAKE_OPAQUE(" + qualified_name + ");\n";
-		}
+		if( it != stl_containers.end() ) { return "PYBIND11_MAKE_OPAQUE(" + qualified_name + ");\n"; }
 	}
 
 	return "";
@@ -576,9 +574,7 @@ string binding_public_data_members(CXXRecordDecl const *C)
 					if( UsingShadowDecl *us = dyn_cast<UsingShadowDecl>(*s) ) {
 						if( FieldDecl *f = dyn_cast<FieldDecl>(us->getTargetDecl()) ) {
 							auto config = Config::get();
-							if ( config.is_field_skipping_requested(f->getQualifiedNameAsString())) {
-								continue;
-							}
+							if( config.is_field_skipping_requested(f->getQualifiedNameAsString()) ) { continue; }
 							if( is_bindable(f) ) c += "\tcl" + bind_data_member(f, class_qualified_name(C)) + ";\n";
 						}
 					}
@@ -589,11 +585,9 @@ string binding_public_data_members(CXXRecordDecl const *C)
 
 	for( auto d = C->decls_begin(); d != C->decls_end(); ++d ) {
 		if( FieldDecl *f = dyn_cast<FieldDecl>(*d) ) {
-			//outs() << "Class: " << class_qualified_name(C); f->dump(); outs() << "\n";
+			// outs() << "Class: " << class_qualified_name(C); f->dump(); outs() << "\n";
 			auto config = Config::get();
-			if ( config.is_field_skipping_requested(f->getQualifiedNameAsString()) ) {
-				continue;
-			}
+			if( config.is_field_skipping_requested(f->getQualifiedNameAsString()) ) { continue; }
 			if( f->getAccess() == AS_public and is_bindable(f) ) c += "\tcl" + bind_data_member(f, class_qualified_name(C)) + ";\n";
 		}
 	}
@@ -604,7 +598,7 @@ string binding_public_data_members(CXXRecordDecl const *C)
 inline string callback_structure_name(CXXRecordDecl const *C)
 {
 	string ns = replace_(namespace_from_named_decl(C), "::", "_");
-	return mangle_type_name( "PyCallBack_" + (ns.empty() ? "" : ns + '_') + python_class_name(C), false );
+	return mangle_type_name("PyCallBack_" + (ns.empty() ? "" : ns + '_') + python_class_name(C), false);
 }
 
 
@@ -752,7 +746,7 @@ string bind_member_functions_for_call_back(CXXRecordDecl const *C, string const 
 				if( return_type.find(',') != std::string::npos ) {
 					string return_type_alias = "_binder_ret_" + std::to_string(ret_id);
 					++ret_id;
-					if (begins_with(return_type,"class ")) return_type = return_type.substr(6);
+					if( begins_with(return_type, "class ") ) return_type = return_type.substr(6);
 					c += "\tusing {} = {};\n"_format(return_type_alias, return_type);
 					return_type = std::move(return_type_alias);
 				}
@@ -770,8 +764,8 @@ string bind_member_functions_for_call_back(CXXRecordDecl const *C, string const 
 				c += "\t{} {}({}){} {}override {{"_format(return_type, m->getNameAsString(), std::get<0>(args), m->isConst() ? " const" : "", exception_specification);
 
 				string member_function_name = namespace_from_named_decl(C);
-				if ( member_function_name.length() > 0 ) member_function_name += "::";
-				member_function_name +=  C->getNameAsString() + "::" + m->getNameAsString();
+				if( member_function_name.length() > 0 ) member_function_name += "::";
+				member_function_name += C->getNameAsString() + "::" + m->getNameAsString();
 				string custom_function_info = Config::get().is_custom_trampoline_function_requested(member_function_name);
 				if( custom_function_info == "" ) {
 					c += indent(fmt::format(call_back_function_body_template, class_name, /*class_qualified_name(C), */ python_name, std::get<1>(args), return_type), "\t\t");
@@ -785,8 +779,7 @@ string bind_member_functions_for_call_back(CXXRecordDecl const *C, string const 
 				else {
 					string input_args = std::get<1>(args);
 					c += "\n\t\treturn {}<{},{}>(this, \"{}\", \"{}\""_format(custom_function_info, C->getNameAsString(), callback_structure_name(C), class_name, m->getNameAsString());
-					if ( input_args.length() > 0 )
-						c += ", {}"_format(std::get<1>(args));
+					if( input_args.length() > 0 ) c += ", {}"_format(std::get<1>(args));
 					c += ");\n";
 				}
 				c += "\t}\n";
@@ -853,8 +846,8 @@ string binding_public_member_functions(CXXRecordDecl const *C, bool callback_str
 							if( is_bindable(m) and !is_skipping_requested(m, Config::get()) and !isa<CXXConstructorDecl>(m) and !isa<CXXDestructorDecl>(m) and !is_const_overload(m) ) {
 								// Create a new CXXRecordDecl and insert base method into inherited class so bind_function correctly resolve parent namespace for function as 'child::' instead of
 								// 'base::' CXXRecordDecl NC(*C); CXXMethodDecl *nm = CXXMethodDecl::Create(m->getParentASTContext(), &NC, m->getLocStart(), m->getNameInfo(), m->getType(),
-								// m->getTypeSourceInfo(), 										  m->getStorageClass(), m->isInlineSpecified(), m->isConstexpr() , m->getLocStart()); it looks like LLVM will
-								// delete this object when parent CXXRecordDecl is destroyed so commenting out for now... // delete nm;
+								// m->getTypeSourceInfo(), 										  m->getStorageClass(), m->isInlineSpecified(), m->isConstexpr() , m->getLocStart()); it looks like LLVM
+								// will delete this object when parent CXXRecordDecl is destroyed so commenting out for now... // delete nm;
 								c += bind_function("\tcl", m, context, C, /*always_use_lambda=*/true);
 							}
 						}
@@ -933,10 +926,8 @@ string bind_forward_declaration(CXXRecordDecl const *C, Context &context)
 	string c = "\t// Forward declaration for: " + qualified_name + " file:" + (include.size() ? include.substr(1, include.size() - 2) : "") + " line:" + line_number(C) + "\n";
 
 	string maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name);
-	//Check if the type is a custom shared pointer:
-	if( is_inherited_from_enable_shared_from_this(C) ) {
-		maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name);
-	}
+	// Check if the type is a custom shared pointer:
+	if( is_inherited_from_enable_shared_from_this(C) ) { maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name); }
 	else if( CXXDestructorDecl *d = C->getDestructor() ) {
 		if( d->getAccess() != AS_public ) maybe_holder_type = ", " + qualified_name + '*';
 	}
@@ -1036,7 +1027,8 @@ string bind_constructor(ConstructorBindingInfo const &CBI, uint args_to_bind, bo
 	if( O_annotate_functions ) {
 		clang::FunctionDecl const *F = CBI.T;
 		string const include = relevant_include(F);
-		c += "\t// function-signature: " + function_qualified_name(F, true) + "(" + function_arguments(F) + ") file:" + (include.size() ? include.substr(1, include.size() - 2) : "") + " line:" + line_number(F) + "\n";
+		c += "\t// function-signature: " + function_qualified_name(F, true) + "(" + function_arguments(F) + ") file:" + (include.size() ? include.substr(1, include.size() - 2) : "") +
+			 " line:" + line_number(F) + "\n";
 	}
 
 	if( args_to_bind == CBI.T->getNumParams() and not CBI.T->isVariadic() ) {
@@ -1079,9 +1071,10 @@ string bind_default_constructor(ConstructorBindingInfo const &CBI) // CXXRecordD
 	string code;
 	if( O_annotate_functions ) {
 		clang::FunctionDecl const *F = CBI.T;
-		if(F) {
+		if( F ) {
 			string const include = relevant_include(F);
-			code += "\t// function-signature: " + function_qualified_name(F, true) + "(" + function_arguments(F) + ") file:" + (include.size() ? include.substr(1, include.size() - 2) : "") + " line:" + line_number(F) + "\n";
+			code += "\t// function-signature: " + function_qualified_name(F, true) + "(" + function_arguments(F) + ") file:" + (include.size() ? include.substr(1, include.size() - 2) : "") +
+					" line:" + line_number(F) + "\n";
 		}
 		else {
 			code += "\t// function-signature: " + CBI.class_qualified_name + "()\n";
@@ -1108,7 +1101,8 @@ string bind_copy_constructor(ConstructorBindingInfo const &CBI) // CXXConstructo
 	if( O_annotate_functions ) {
 		clang::FunctionDecl const *F = CBI.T;
 		string const include = relevant_include(F);
-		code += "\t// function-signature: " + function_qualified_name(F, true) + "(" + function_arguments(F) + ") file:" + (include.size() ? include.substr(1, include.size() - 2) : "") + " line:" + line_number(F) + "\n";
+		code += "\t// function-signature: " + function_qualified_name(F, true) + "(" + function_arguments(F) + ") file:" + (include.size() ? include.substr(1, include.size() - 2) : "") +
+				" line:" + line_number(F) + "\n";
 	}
 	// CXXRecordDecl const *C = T->getParent();
 
@@ -1133,21 +1127,18 @@ string bind_copy_constructor(ConstructorBindingInfo const &CBI) // CXXConstructo
 	string const_bit;
 
 	CBI.T->isCopyConstructor(typequals);
-	if( typequals == Qualifiers::TQ::Const ) {
-		const_bit += " const";
-	}
+	if( typequals == Qualifiers::TQ::Const ) { const_bit += " const"; }
 
 	if( CBI.trampoline ) {
 		if( CBI.C->isAbstract() ) code += "\tcl.def(pybind11::init<{}{} &>());\n"_format(CBI.trampoline_qualified_name, const_bit);
 		else {
 			// not yet supported by Pybind11? return "\tcl.def( pybind11::init( []({0} const &o){{ return new {0}(o); }}, []({1} const &o){{ return new {1}(o); }} )
 			// );\n"_format(CBI.class_qualified_name, CBI.binding_qualified_name);
-			code += \
-				"\tcl.def( pybind11::init( []({0}{1} &o){{ return new {0}(o); }} ) );\n"_format(CBI.trampoline_qualified_name, const_bit) +
-				(CBI.T->getAccess() == AS_public ? "\tcl.def( pybind11::init( []({0}{1} &o){{ return new {0}(o); }} ) );\n"_format(CBI.class_qualified_name, const_bit) : "");
+			code += "\tcl.def( pybind11::init( []({0}{1} &o){{ return new {0}(o); }} ) );\n"_format(CBI.trampoline_qualified_name, const_bit) +
+					(CBI.T->getAccess() == AS_public ? "\tcl.def( pybind11::init( []({0}{1} &o){{ return new {0}(o); }} ) );\n"_format(CBI.class_qualified_name, const_bit) : "");
 		}
 	}
-	else code +=  "\tcl.def( pybind11::init( []({0}{1} &o){{ return new {0}(o); }} ) );\n"_format(CBI.class_qualified_name, const_bit);
+	else code += "\tcl.def( pybind11::init( []({0}{1} &o){{ return new {0}(o); }} ) );\n"_format(CBI.class_qualified_name, const_bit);
 
 	return code;
 }
@@ -1173,18 +1164,18 @@ std::string ClassBinder::bind_repr(Context &context, Config const &config)
 {
 	string c;
 	string qualified_name = class_qualified_name(C);
-	if( config.is_function_skipping_requested(qualified_name + "::__str__") or config.is_function_skipping_requested( standard_name(C->getQualifiedNameAsString() + "::__str__" ) ) ) return c;
+	if( config.is_function_skipping_requested(qualified_name + "::__str__") or config.is_function_skipping_requested(standard_name(C->getQualifiedNameAsString() + "::__str__")) ) return c;
 
 	if( FunctionDecl const *F = context.global_insertion_operator(C) ) {
-		//outs() << "Found insertion operator for: " << class_qualified_name(C) << "\n";
-		//outs() << "insertion operator: " << F->getNameInfo().getAsString() << " qn: " << F->getQualifiedNameAsString() << " dn:" << F->getDeclName() << "\n";
+		// outs() << "Found insertion operator for: " << class_qualified_name(C) << "\n";
+		// outs() << "insertion operator: " << F->getNameInfo().getAsString() << " qn: " << F->getQualifiedNameAsString() << " dn:" << F->getDeclName() << "\n";
 
 		string maybe_using_decl;
 
 		string ns = namespace_from_named_decl(F);
-		if(ns.size()) maybe_using_decl = " using namespace {};"_format(ns);
+		if( ns.size() ) maybe_using_decl = " using namespace {};"_format(ns);
 
-		//c += "\n\tcl.def(\"__str__\", []({} const &o) -> std::string {{ std::ostringstream s; {}(s, o); return s.str(); }} );\n"_format(qualified_name, F->getQualifiedNameAsString());
+		// c += "\n\tcl.def(\"__str__\", []({} const &o) -> std::string {{ std::ostringstream s; {}(s, o); return s.str(); }} );\n"_format(qualified_name, F->getQualifiedNameAsString());
 		c += "\n\tcl.def(\"__str__\", []({} const &o) -> std::string {{ std::ostringstream s;{} s << o; return s.str(); }} );\n"_format(qualified_name, maybe_using_decl);
 
 		prefix_includes_.push_back(F);
@@ -1242,7 +1233,7 @@ void ClassBinder::bind(Context &context)
 	string const qualified_name = class_qualified_name(C);
 	string const qualified_name_without_template = standard_name(C->getQualifiedNameAsString());
 
-	//prefix_code_ += generate_opaque_declaration_if_needed(qualified_name, qualified_name_without_template);
+	// prefix_code_ += generate_opaque_declaration_if_needed(qualified_name, qualified_name_without_template);
 
 	std::map<string, string> const &external_binders = Config::get().binders();
 	if( external_binders.count(qualified_name_without_template) ) {
@@ -1281,9 +1272,7 @@ void ClassBinder::bind(Context &context)
 
 	string maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name);
 
-	if( is_inherited_from_enable_shared_from_this(C) ) {
-		maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name);
-	}
+	if( is_inherited_from_enable_shared_from_this(C) ) { maybe_holder_type = ", {}<{}>"_format(holder_type, qualified_name); }
 	else if( CXXDestructorDecl *d = C->getDestructor() ) {
 		if( d->getAccess() != AS_public ) maybe_holder_type = ", " + qualified_name + '*';
 	}
@@ -1291,25 +1280,19 @@ void ClassBinder::bind(Context &context)
 
 	// Add module local if requested for the namespace
 	std::string module_local_annotation = "";
-	if (Config::get().is_module_local_requested(namespace_from_named_decl(C)))
-		module_local_annotation = ", pybind11::module_local()";
+	if( Config::get().is_module_local_requested(namespace_from_named_decl(C)) ) module_local_annotation = ", pybind11::module_local()";
 
 	// Add buffer protocol if requested
 	std::string buffer_protocol_annotation = "";
-	if (Config::get().is_buffer_protocol_requested(qualified_name_without_template))
-		buffer_protocol_annotation = ", pybind11::buffer_protocol()";
+	if( Config::get().is_buffer_protocol_requested(qualified_name_without_template) ) buffer_protocol_annotation = ", pybind11::buffer_protocol()";
 
 	std::string extra_annotation = module_local_annotation + buffer_protocol_annotation;
 
 	if( named_class ) {
-		if (Config::get().is_smart_holder_requested(qualified_name_without_template)) {
-			c += '\t' +
-				R"(PYBIND11_TYPE_CASTER_BASE_HOLDER({} {}))"_format(qualified_name, maybe_holder_type) +
-				'\n';
-		}
+		if( Config::get().is_smart_holder_requested(qualified_name_without_template) ) { c += '\t' + R"(PYBIND11_TYPE_CASTER_BASE_HOLDER({} {}))"_format(qualified_name, maybe_holder_type) + '\n'; }
 		c += '\t' +
 			 R"(pybind11::class_<{}{}{}{}> cl({}, "{}", "{}"{});)"_format(qualified_name, maybe_holder_type, maybe_trampoline, maybe_base_classes(context), module_variable_name, python_class_name(C),
-																		generate_documentation_string_for_declaration(C), extra_annotation) +
+																		  generate_documentation_string_for_declaration(C), extra_annotation) +
 			 '\n';
 	}
 	// c += "\tpybind11::handle cl_type = cl;\n\n";
@@ -1325,14 +1308,14 @@ void ClassBinder::bind(Context &context)
 			if( t->getAccess() == AS_public and !t->isMoveConstructor() and is_bindable(*t) and !is_skipping_requested(*t, Config::get()) /*and  t->doesThisDeclarationHaveABody()*/ ) {
 				ConstructorBindingInfo CBI = {C, *t, trampoline, qualified_name, trampoline_name, context};
 
-				if( t->isCopyConstructor() /*and  not copy_constructor_processed*/ and !is_skipping_requested(*t, Config::get() ) ) {
+				if( t->isCopyConstructor() /*and  not copy_constructor_processed*/ and !is_skipping_requested(*t, Config::get()) ) {
 					// constructors += "\tcl.def(pybind11::init<{} const &>());\n"_format(binding_qualified_name);
 					//(*t) -> dump();
-					//constructors += "// CC " + standard_name(t->getQualifiedNameAsString()) + "\n";
-					//constructors += "// CC " + function_qualified_name(*t, true) + "\n";
+					// constructors += "// CC " + standard_name(t->getQualifiedNameAsString()) + "\n";
+					// constructors += "// CC " + function_qualified_name(*t, true) + "\n";
 					constructors += bind_copy_constructor(CBI);
-					//constructors += "// CC \n";
-					// copy_constructor_processed = true;
+					// constructors += "// CC \n";
+					//  copy_constructor_processed = true;
 				}
 				else if( t->isDefaultConstructor() and t->getNumParams() == 0 ) constructors += bind_default_constructor(CBI); // workaround for Pybind11-2.2 issues
 				else constructors += bind_constructor(CBI);
@@ -1390,7 +1373,7 @@ void ClassBinder::bind(Context &context)
 		if( EnumDecl *e = dyn_cast<EnumDecl>(*d) ) {
 			if( e->getAccess() == AS_public and is_bindable(e) ) {
 				if( is_skipping_requested(e, Config::get()) ) {
-					//outs() << "Skipping inner class Enum: " << e->getQualifiedNameAsString() << "\n";
+					// outs() << "Skipping inner class Enum: " << e->getQualifiedNameAsString() << "\n";
 				}
 				else {
 					c += '\n';

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -18,8 +18,8 @@
 
 #include <llvm/Support/raw_ostream.h>
 
-#include <sstream>
 #include <fstream>
+#include <sstream>
 #include <stdexcept>
 
 using namespace llvm;
@@ -102,7 +102,7 @@ void Config::read(string const &file_name)
 	string line;
 
 	while( std::getline(f, line) ) {
-			if( line.empty() or line[0] == '#' ) continue;
+		if( line.empty() or line[0] == '#' ) continue;
 
 		if( line.back() == '\r' ) {
 			line.pop_back();
@@ -139,7 +139,7 @@ void Config::read(string const &file_name)
 		}
 		else if( token == _python_builtin_ ) {
 
-			if (bind) python_builtins.insert(name_without_spaces);
+			if( bind ) python_builtins.insert(name_without_spaces);
 			else not_python_builtins.insert(name_without_spaces);
 		}
 		else if( token == _function_ ) {
@@ -173,14 +173,10 @@ void Config::read(string const &file_name)
 			}
 		}
 		else if( token == _buffer_protocol_ ) {
-			if(bind) {
-				buffer_protocols.push_back(name_without_spaces);
-			}
+			if( bind ) { buffer_protocols.push_back(name_without_spaces); }
 		}
-		else if( token == _module_local_namespace_) {
-			if(bind) {
-				module_local_namespaces_to_add.push_back(name_without_spaces);
-			}
+		else if( token == _module_local_namespace_ ) {
+			if( bind ) { module_local_namespaces_to_add.push_back(name_without_spaces); }
 			else {
 				module_local_namespaces_to_skip.push_back(name_without_spaces);
 			}
@@ -212,18 +208,15 @@ void Config::read(string const &file_name)
 				auto binder_function = split_in_two(name, "Invalid line for add_on_binder_for_namespace specification! Must be: name_of_type + <space or tab> + name_of_binder. Got: " + line);
 				add_on_binder_for_namespaces_[binder_function.first] = trim(binder_function.second);
 			}
-		} else if ( token == _field_ ) {
+		}
+		else if( token == _field_ ) {
 
-			if (!bind) {
-				fields_to_skip.push_back(name_without_spaces);
-			}
+			if( !bind ) { fields_to_skip.push_back(name_without_spaces); }
 		}
 		else if( token == _custom_shared_ ) holder_type_ = name_without_spaces;
 
 		else if( token == _smart_holder_ ) {
-			if(bind) {
-				smart_held_classes.push_back(name_without_spaces);
-			}
+			if( bind ) { smart_held_classes.push_back(name_without_spaces); }
 		}
 
 		else if( token == _pybind11_include_file_ ) {
@@ -243,7 +236,8 @@ void Config::read(string const &file_name)
 
 		else if( token == _trampoline_member_function_binder_ ) {
 			if( bind ) {
-				auto member_function_name_and_function_name = split_in_two(name, "Invalid line for trampoline_member_function_binder specification! Must be: qualified_class_name::member_funtion_name + <space or tab> + name_of_function. Got: " + line);
+				auto member_function_name_and_function_name = split_in_two(
+					name, "Invalid line for trampoline_member_function_binder specification! Must be: qualified_class_name::member_funtion_name + <space or tab> + name_of_function. Got: " + line);
 				custom_trampoline_functions_[member_function_name_and_function_name.first] = member_function_name_and_function_name.second;
 			}
 		}
@@ -440,17 +434,16 @@ bool Config::is_module_local_requested(string const &namespace_) const
 	auto module_local_all = std::find(module_local_namespaces_to_add.begin(), module_local_namespaces_to_add.end(), namespace_all);
 	if( module_local_all != module_local_namespaces_to_add.end() ) {
 		auto module_local_to_skip = std::find(module_local_namespaces_to_skip.begin(), module_local_namespaces_to_skip.end(), namespace_);
-		if( module_local_to_skip != module_local_namespaces_to_skip.end()) {
-			return false;
-		}
+		if( module_local_to_skip != module_local_namespaces_to_skip.end() ) { return false; }
 		return true;
 	}
 
 	auto module_local_to_add = std::find(module_local_namespaces_to_add.begin(), module_local_namespaces_to_add.end(), namespace_);
-	if( module_local_to_add != module_local_namespaces_to_add.end()) {
+	if( module_local_to_add != module_local_namespaces_to_add.end() ) {
 		auto module_local_to_skip = std::find(module_local_namespaces_to_skip.begin(), module_local_namespaces_to_skip.end(), namespace_);
-		if( module_local_to_skip != module_local_namespaces_to_skip.end()) {
-			throw std::runtime_error("Could not determent if namespace '" + namespace_ + "' should use module_local or not... please resolve the conlficting options +module_local_namespace and -module_local_namespace!!!");
+		if( module_local_to_skip != module_local_namespaces_to_skip.end() ) {
+			throw std::runtime_error("Could not determent if namespace '" + namespace_ +
+									 "' should use module_local or not... please resolve the conlficting options +module_local_namespace and -module_local_namespace!!!");
 		}
 		return true;
 	}
@@ -486,8 +479,8 @@ string Config::includes_code() const
 {
 	std::ostringstream s;
 	for( auto &i : includes_to_add ) s << "#include " << i << "\n";
-	if (O_include_pybind11_stl) s << "#include <pybind11/stl.h>\n";
-	if (s.tellp() != std::streampos(0)) s << '\n';
+	if( O_include_pybind11_stl ) s << "#include <pybind11/stl.h>\n";
+	if( s.tellp() != std::streampos(0) ) s << '\n';
 	return s.str();
 }
 

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -14,8 +14,8 @@
 #ifndef _INCLUDED_config_hpp_
 #define _INCLUDED_config_hpp_
 
-#include <set>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -32,8 +32,10 @@ class Config
 
 	Config() {}
 
-	Config(string const &root_module_, std::vector<string> namespaces_to_bind_, std::vector<string> namespaces_to_skip_, string const &prefix_, std::size_t maximum_file_length_, bool skip_line_number_)
-		: root_module(root_module_), namespaces_to_bind(namespaces_to_bind_), namespaces_to_skip(namespaces_to_skip_), prefix(prefix_), maximum_file_length(maximum_file_length_), skip_line_number(skip_line_number_)
+	Config(string const &root_module_, std::vector<string> namespaces_to_bind_, std::vector<string> namespaces_to_skip_, string const &prefix_, std::size_t maximum_file_length_,
+		   bool skip_line_number_)
+		: root_module(root_module_), namespaces_to_bind(namespaces_to_bind_), namespaces_to_skip(namespaces_to_skip_), prefix(prefix_), maximum_file_length(maximum_file_length_),
+		  skip_line_number(skip_line_number_)
 	{
 	}
 

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -437,11 +437,12 @@ void Context::generate(Config const &config)
 
 		string const holder_type = Config::get().holder_type();
 
-		string shared_declare = "PYBIND11_DECLARE_HOLDER_TYPE(T, "+holder_type+"<T>, false)";
-		string shared_make_opaque = "PYBIND11_MAKE_OPAQUE("+holder_type+"<void>)";
+		string shared_declare = "PYBIND11_DECLARE_HOLDER_TYPE(T, " + holder_type + "<T>, false)";
+		string shared_make_opaque = "PYBIND11_MAKE_OPAQUE(" + holder_type + "<void>)";
 
 		string const pybind11_include = "#include <" + Config::get().pybind11_include_file() + ">";
-		code = generate_include_directives(includes) + fmt::format(module_header, pybind11_include, config.includes_code(), shared_declare, shared_make_opaque) + prefix_code + "void " + function_name + module_function_suffix + "\n{\n" + code + "}\n";
+		code = generate_include_directives(includes) + fmt::format(module_header, pybind11_include, config.includes_code(), shared_declare, shared_make_opaque) + prefix_code + "void " +
+			   function_name + module_function_suffix + "\n{\n" + code + "}\n";
 
 		if( O_single_file ) root_module_file_handle << "// File: " << file_name << '\n' << code << "\n\n";
 		else update_source_file(config.prefix, file_name, code);

--- a/source/enum.cpp
+++ b/source/enum.cpp
@@ -59,10 +59,10 @@ bool is_bindable(EnumDecl const *E)
 /// check if user requested binding for the given declaration
 bool is_binding_requested(clang::EnumDecl const *E, Config const &config)
 {
-	if( config.is_enum_binding_requested( E->getQualifiedNameAsString() ) ) return true;
+	if( config.is_enum_binding_requested(E->getQualifiedNameAsString()) ) return true;
 
 	bool bind = config.is_namespace_binding_requested(namespace_from_named_decl(E));
-	//for( auto &t : get_type_dependencies(E) ) bind &= !is_skipping_requested(t, config);
+	// for( auto &t : get_type_dependencies(E) ) bind &= !is_skipping_requested(t, config);
 	return bind;
 }
 
@@ -76,7 +76,7 @@ bool is_skipping_requested(clang::EnumDecl const *E, Config const &config)
 
 	bool skip = config.is_namespace_skipping_requested(namespace_from_named_decl(E));
 
-	//for( auto &t : get_type_dependencies(E) ) skip |= is_skipping_requested(t, config);
+	// for( auto &t : get_type_dependencies(E) ) skip |= is_skipping_requested(t, config);
 
 	return skip;
 }
@@ -123,8 +123,7 @@ std::string bind_enum(std::string const &module, EnumDecl const *E)
 
 	// Add module local if requested for the namespace
 	std::string module_local_annotation = "";
-	if (Config::get().is_module_local_requested(namespace_from_named_decl(E)))
-		module_local_annotation = ", pybind11::module_local()";
+	if( Config::get().is_module_local_requested(namespace_from_named_decl(E)) ) module_local_annotation = ", pybind11::module_local()";
 
 	string r = "\tpybind11::enum_<{}>({}, \"{}\"{}, \"{}\"{})\n"_format(qualified_name, module, name, maybe_arithmetic, generate_documentation_string_for_declaration(E), module_local_annotation);
 
@@ -160,8 +159,8 @@ bool EnumBinder::bindable() const
 /// check if user requested binding for the given declaration
 void EnumBinder::request_bindings_and_skipping(Config const &config, RequestFlags flags)
 {
-	if( (flags&RequestFlags::skipping) and is_skipping_requested(E, config) ) Binder::request_skipping();
-	else if( (flags&RequestFlags::binding) and is_binding_requested(E, config) ) Binder::request_bindings();
+	if( (flags & RequestFlags::skipping) and is_skipping_requested(E, config) ) Binder::request_skipping();
+	else if( (flags & RequestFlags::binding) and is_binding_requested(E, config) ) Binder::request_bindings();
 }
 
 

--- a/source/function.cpp
+++ b/source/function.cpp
@@ -23,7 +23,7 @@
 
 #include <clang/AST/ExprCXX.h>
 
-//#include <tsl/robin_map.h>
+// #include <tsl/robin_map.h>
 
 #include <vector>
 
@@ -44,8 +44,9 @@ namespace binder {
 // Return the python operator that maps to the C++ operator; returns "" if no mapping exists
 // This correctly handles operators that have multiple meanings depending on their argument count
 // For example, operator_(this, other) maps to __sub__ while operator-(this) maps to __neg__
-string cpp_python_operator(const FunctionDecl & F) {
-	static std::map<string, vector<string>> const m {
+string cpp_python_operator(const FunctionDecl &F)
+{
+	static std::map<string, vector<string>> const m{
 		{"operator+", {"__pos__", "__add__"}}, //
 		{"operator-", {"__neg__", "__sub__"}}, //
 		{"operator*", {"dereference", "__mul__"}}, //
@@ -78,10 +79,10 @@ string cpp_python_operator(const FunctionDecl & F) {
 		{"operator--", {"pre_decrement", "post_decrement"}}, //
 
 		{"operator->", {"arrow"}} //
-  };
-	const auto & found = m.find(F.getNameAsString());
-	if (found != m.end()) {
-		const auto & vec = found->second;
+	};
+	const auto &found = m.find(F.getNameAsString());
+	if( found != m.end() ) {
+		const auto &vec = found->second;
 		const auto n = F.getNumParams();
 		return n < vec.size() ? vec[n] : vec.back();
 	}
@@ -95,7 +96,7 @@ string function_arguments(clang::FunctionDecl const *record)
 	string r;
 
 	for( uint i = 0; i < record->getNumParams(); ++i ) {
-		//r += standard_name(record->getParamDecl(i)->getOriginalType().getCanonicalType().getAsString());
+		// r += standard_name(record->getParamDecl(i)->getOriginalType().getCanonicalType().getAsString());
 		r += standard_name(record->getParamDecl(i)->getOriginalType());
 		if( i + 1 != record->getNumParams() ) r += ", ";
 	}
@@ -226,9 +227,7 @@ string template_specialization(FunctionDecl const *F)
 // generate string represetiong class name that could be used in python
 string python_function_name(FunctionDecl const *F)
 {
-	if( F->isOverloadedOperator() ) {
-		return cpp_python_operator(*F);
-	}
+	if( F->isOverloadedOperator() ) { return cpp_python_operator(*F); }
 	else {
 		// if( auto m = dyn_cast<CXXMethodDecl>(F) ) {
 		// }
@@ -246,7 +245,7 @@ string python_function_name(FunctionDecl const *F)
 // Generate function pointer type string for given function: void (*)(int, doule)_ or  void (ClassName::*)(int, doule)_ for memeber function
 string function_pointer_type(FunctionDecl const *F)
 {
-	//F->dump();
+	// F->dump();
 	string r;
 	string prefix, maybe_const;
 	if( auto m = dyn_cast<CXXMethodDecl>(F) ) {
@@ -254,7 +253,7 @@ string function_pointer_type(FunctionDecl const *F)
 		maybe_const = m->isConst() ? " const" : "";
 	}
 
-	//r += standard_name(F->getReturnType().getCanonicalType().getAsString());
+	// r += standard_name(F->getReturnType().getCanonicalType().getAsString());
 	r += standard_name(F->getReturnType());
 
 	r += " ({}*)("_format(prefix);
@@ -275,8 +274,8 @@ string function_qualified_name(FunctionDecl const *F, bool omit_return_type)
 	string maybe_const;
 	if( auto m = dyn_cast<CXXMethodDecl>(F) ) maybe_const = m->isConst() ? " const" : "";
 
-	string r = (omit_return_type ? "" : standard_name(F->getReturnType()) + " ") + standard_name(F->getQualifiedNameAsString() + template_specialization(F)) + "(" +
-			   function_arguments(F) + ")" + maybe_const;
+	string r =
+		(omit_return_type ? "" : standard_name(F->getReturnType()) + " ") + standard_name(F->getQualifiedNameAsString() + template_specialization(F)) + "(" + function_arguments(F) + ")" + maybe_const;
 
 	fix_boolean_types(r);
 	return r;
@@ -331,8 +330,10 @@ bool is_skipping_requested(FunctionDecl const *F, Config const &config)
 	string qualified_name = standard_name(F->getQualifiedNameAsString());
 	string qualified_name_with_args_info_and_template_specialization = function_qualified_name(F, true);
 
-	if( config.is_function_skipping_requested(qualified_name_with_args_info_and_template_specialization) ) return true; // qualified function name + parameter and template info was requested for skipping
-	if( config.is_function_binding_requested(qualified_name_with_args_info_and_template_specialization) ) return false; // qualified function name + parameter and template info was requested for binding
+	if( config.is_function_skipping_requested(qualified_name_with_args_info_and_template_specialization) )
+		return true; // qualified function name + parameter and template info was requested for skipping
+	if( config.is_function_binding_requested(qualified_name_with_args_info_and_template_specialization) )
+		return false; // qualified function name + parameter and template info was requested for binding
 
 	if( config.is_function_skipping_requested(qualified_name) ) return true; // qualified function name was requested for skipping
 	if( config.is_function_binding_requested(qualified_name) ) return false; // qualified function name was requested for binding
@@ -373,7 +374,7 @@ string bind_function(FunctionDecl const *F, uint args_to_bind, bool request_bind
 	if( m and m->isStatic() ) {
 		maybe_static = "_static";
 		function_name = Config::get().prefix_for_static_member_functions() + function_name;
-		//outs() << "STATIC: " << function_qualified_name << " → " << function_name << "\n";
+		// outs() << "STATIC: " << function_qualified_name << " → " << function_name << "\n";
 	}
 
 	string function, documentation;
@@ -382,8 +383,8 @@ string bind_function(FunctionDecl const *F, uint args_to_bind, bool request_bind
 
 		documentation = generate_documentation_string_for_declaration(F);
 		if( documentation.size() ) documentation += "\\n\\n";
-		documentation += "C++: " + standard_name(F->getQualifiedNameAsString() + "(" + function_arguments(F) + ')' + (m and m->isConst() ? " const" : "") + " --> " +
-												 standard_name(F->getReturnType() ) );
+		documentation +=
+			"C++: " + standard_name(F->getQualifiedNameAsString() + "(" + function_arguments(F) + ')' + (m and m->isConst() ? " const" : "") + " --> " + standard_name(F->getReturnType()));
 	}
 	else {
 		pair<string, string> args = function_arguments_for_lambda(F, args_to_bind);
@@ -454,7 +455,8 @@ string bind_function(string const &module, FunctionDecl const *F, Context &conte
 
 	if( O_annotate_functions ) {
 		string const include = relevant_include(F);
-		code += "\t// function-signature: " + function_qualified_name(F) + "(" + function_arguments(F) + ") file:" + (include.size() ? include.substr(1, include.size() - 2) : "") + " line:" + line_number(F) + "\n";
+		code += "\t// function-signature: " + function_qualified_name(F) + "(" + function_arguments(F) + ") file:" + (include.size() ? include.substr(1, include.size() - 2) : "") +
+				" line:" + line_number(F) + "\n";
 	}
 
 	int num_params = F->getNumParams();
@@ -544,7 +546,7 @@ bool is_bindable(FunctionDecl const *F)
 	if( it != cache.end() ) return it->second;
 	else {
 		bool r = is_bindable_raw(F);
-		cache.insert( {F, r} );
+		cache.insert({F, r});
 		return r;
 	}
 
@@ -601,8 +603,8 @@ bool FunctionBinder::bindable() const
 /// check if user requested binding for the given declaration
 void FunctionBinder::request_bindings_and_skipping(Config const &config, RequestFlags flags)
 {
-	if( (flags&RequestFlags::skipping) and is_skipping_requested(F, config) ) Binder::request_skipping();
-	else if( (flags&RequestFlags::binding) and is_binding_requested(F, config) ) Binder::request_bindings();
+	if( (flags & RequestFlags::skipping) and is_skipping_requested(F, config) ) Binder::request_skipping();
+	else if( (flags & RequestFlags::binding) and is_binding_requested(F, config) ) Binder::request_bindings();
 }
 
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -28,8 +28,8 @@
 #include <context.hpp>
 #include <enum.hpp>
 #include <function.hpp>
-#include <options.hpp>
 #include <iostream>
+#include <options.hpp>
 
 using namespace clang::tooling;
 using namespace llvm;
@@ -226,9 +226,10 @@ public:
 int main(int argc, const char **argv)
 {
 #if( LLVM_VERSION_MAJOR < 6 )
-	llvm::cl::SetVersionPrinter([]() { std::cout<< "binder " << BINDER_VERSION_STRING << "\nLLVM " << LLVM_VERSION_MAJOR << "." << LLVM_VERSION_MINOR << "." << LLVM_VERSION_PATCH << "\n"; });
+	llvm::cl::SetVersionPrinter([]() { std::cout << "binder " << BINDER_VERSION_STRING << "\nLLVM " << LLVM_VERSION_MAJOR << "." << LLVM_VERSION_MINOR << "." << LLVM_VERSION_PATCH << "\n"; });
 #else
-	llvm::cl::SetVersionPrinter([](llvm::raw_ostream &OS) { OS << "binder " << BINDER_VERSION_STRING << "\nLLVM " << LLVM_VERSION_MAJOR << "." << LLVM_VERSION_MINOR << "." << LLVM_VERSION_PATCH << "\n"; });
+	llvm::cl::SetVersionPrinter(
+		[](llvm::raw_ostream &OS) { OS << "binder " << BINDER_VERSION_STRING << "\nLLVM " << LLVM_VERSION_MAJOR << "." << LLVM_VERSION_MINOR << "." << LLVM_VERSION_PATCH << "\n"; });
 #endif
 #if( LLVM_VERSION_MAJOR < 13 )
 	CommonOptionsParser op(argc, argv, BinderToolCategory);

--- a/source/options.cpp
+++ b/source/options.cpp
@@ -33,7 +33,7 @@ cl::opt<bool> O_flat("flat", cl::desc("When specified generated files into singl
 					 cl::init(false), cl::cat(BinderToolCategory));
 
 cl::opt<bool> O_include_pybind11_stl("include-pybind11-stl", cl::desc("When specified bindings for STL classes in <pybind11/stl.h> will be used instead of generating custom STL bindings."),
-					 cl::init(false), cl::cat(BinderToolCategory));
+									 cl::init(false), cl::cat(BinderToolCategory));
 
 
 cl::opt<std::string> O_root_module("root-module", cl::desc("Name of root module"), /*cl::init("example"),*/ cl::cat(BinderToolCategory));

--- a/source/stl_binders.hpp
+++ b/source/stl_binders.hpp
@@ -64,15 +64,14 @@ public:
 template <typename Key, typename T, typename Compare, class Allocator> class map_binder
 {
 public:
-	map_binder(pybind11::module &m, std::string const &key_name, std::string const &value_name, std::string const & comparator_name, std::string const & allocator_name)
+	map_binder(pybind11::module &m, std::string const &key_name, std::string const &value_name, std::string const &comparator_name, std::string const &allocator_name)
 	{
 		using Map = std::map<Key, T, Compare, Allocator>;
 		using holder_type = std::shared_ptr< std::map<Key, T, Compare, Allocator> >;
 		using Class_ = pybind11::class_<Map, holder_type>;
 
-		std::string maybe_extra =
-			( (comparator_name == "std_less_" + key_name + "_t") ? "" : ("_" + comparator_name) ) +
-			( (allocator_name == "std_allocator_std_pair_const_" + key_name + '_' + value_name + "_t") ? "" : ("_" + allocator_name) );
+		std::string maybe_extra = ((comparator_name == "std_less_" + key_name + "_t") ? "" : ("_" + comparator_name)) +
+								  ((allocator_name == "std_allocator_std_pair_const_" + key_name + '_' + value_name + "_t") ? "" : ("_" + allocator_name));
 
 		Class_ cl = pybind11::bind_map<Map, holder_type>(m, "map_" + key_name + '_' + value_name + maybe_extra);
 	}

--- a/source/type.cpp
+++ b/source/type.cpp
@@ -20,12 +20,12 @@
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/ExprCXX.h>
 #include <clang/Basic/SourceManager.h>
-#include <llvm/Support/Regex.h>
 #include <llvm/ADT/StringMap.h>
+#include <llvm/Support/Regex.h>
 
-//#include <tsl/robin_map.h>
+// #include <tsl/robin_map.h>
 
-//#include <experimental/filesystem>
+// #include <experimental/filesystem>
 #include <cstdlib>
 #include <fstream>
 
@@ -458,10 +458,10 @@ void request_bindings(clang::QualType const &qt, Context &context)
 /// return standard string representation of a given type
 std::string standard_name(clang::QualType const &qt)
 {
-	//qt.getUnqualifiedType().dump();
-	//qt->getCanonicalTypeInternal().dump();
-	//qt.getTypePtr()->dump();
-	//outs() << qt->getTypeClassName() << '\n';
+	// qt.getUnqualifiedType().dump();
+	// qt->getCanonicalTypeInternal().dump();
+	// qt.getTypePtr()->dump();
+	// outs() << qt->getTypeClassName() << '\n';
 
 	string r = qt.getAsString();
 
@@ -482,7 +482,9 @@ std::string standard_name(clang::QualType const &qt)
 	// if( standard_names.count(r) ) return r;
 	// else return standard_name(qt.getCanonicalType().getAsString());
 
-	static std::set<string> standard_names_to_ignore {"std::size_t", }; // "std::array::size_type",
+	static std::set<string> standard_names_to_ignore{
+		"std::size_t",
+	}; // "std::array::size_type",
 	if( standard_names_to_ignore.count(r) ) return r;
 	else return standard_name(qt.getCanonicalType().getAsString());
 }
@@ -688,18 +690,30 @@ bool is_python_builtin(NamedDecl const *C)
 
 	static std::set<string> const known_builtin = {
 		//"std::nullptr_t", "nullptr_t",
-		"std::basic_string", "std::initializer_list", "std::__1::basic_string",
+		"std::basic_string",
+		"std::initializer_list",
+		"std::__1::basic_string",
 
-		"std::allocator", "std::__allocator_destructor",
+		"std::allocator",
+		"std::__allocator_destructor",
 
-		Config::get().holder_type(), "std::shared_ptr", "std::enable_shared_from_this", "std::__shared_ptr", // "std::weak_ptr",  "std::__weak_ptr"
+		Config::get().holder_type(),
+		"std::shared_ptr",
+		"std::enable_shared_from_this",
+		"std::__shared_ptr", // "std::weak_ptr",  "std::__weak_ptr"
 		"std::unique_ptr",
 		//"std::__1::shared_ptr", "std::__1::weak_ptr", "std::__1::allocator",
 
-		"std::pair", "std::tuple",
+		"std::pair",
+		"std::tuple",
 		//"std::__1::pair", "std::__1::tuple",
 
-		"std::_Rb_tree_iterator", "std::_Rb_tree_const_iterator", "__gnu_cxx::__normal_iterator", "std::_List_iterator", "std::_List_const_iterator", "std::__list_node",
+		"std::_Rb_tree_iterator",
+		"std::_Rb_tree_const_iterator",
+		"__gnu_cxx::__normal_iterator",
+		"std::_List_iterator",
+		"std::_List_const_iterator",
+		"std::__list_node",
 
 		"std::__wrap_iter",
 		//"std::__1::__wrap_iter",
@@ -711,11 +725,16 @@ bool is_python_builtin(NamedDecl const *C)
 
 		"std::__value_type",
 
-		"std::__detail::_Hash_node_base", "std::__detail::_Hash_node", "std::__detail::_Node_iterator", "std::__detail::_Node_iterator_base", "std::__detail::_Node_const_iterator",
+		"std::__detail::_Hash_node_base",
+		"std::__detail::_Hash_node",
+		"std::__detail::_Node_iterator",
+		"std::__detail::_Node_iterator_base",
+		"std::__detail::_Node_const_iterator",
 
 		"std::__hash_value_type",
 
-		"std::function", "std::complex",
+		"std::function",
+		"std::complex",
 
 		// pybind11 types
 		// https://pybind11.readthedocs.io/en/stable/advanced/pycpp/object.html
@@ -773,14 +792,11 @@ bool is_python_builtin(NamedDecl const *C)
 	};
 
 	// Not builtin's
-	if (Config::get().not_python_builtins.count(name))
-		return false;
+	if( Config::get().not_python_builtins.count(name) ) return false;
 	// Builtins
-	if (Config::get().python_builtins.count(name) || known_builtin.count(name))
-		return true;
+	if( Config::get().python_builtins.count(name) || known_builtin.count(name) ) return true;
 	// STL
-	if (O_include_pybind11_stl && stl_builtin.count(name))
-		return true;
+	if( O_include_pybind11_stl && stl_builtin.count(name) ) return true;
 
 	return false;
 }

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -22,7 +22,7 @@
 #include <clang/AST/ExprCXX.h>
 #include <clang/Basic/SourceManager.h>
 
-//#include <experimental/filesystem>
+// #include <experimental/filesystem>
 #include <cctype>
 #include <cstdlib>
 #include <fstream>
@@ -69,7 +69,7 @@ void replace_reverse(string &r, string const &from, string const &to)
 void replace(string &r, string const &from, string const &to)
 {
 	std::string::size_type i = 0;
-	while( ( i = r.find(from, i) ) != std::string::npos ) {
+	while( (i = r.find(from, i)) != std::string::npos ) {
 		r.replace(i, from.size(), to);
 		i += to.size();
 	}
@@ -115,12 +115,12 @@ std::string trim(std::string const &s)
 {
 	static std::string const whitespaces = " \t";
 
-    auto begin = s.find_first_not_of(whitespaces);
-    if(begin == std::string::npos) return "";
+	auto begin = s.find_first_not_of(whitespaces);
+	if( begin == std::string::npos ) return "";
 
 	auto end = s.find_last_not_of(whitespaces);
 
-    return s.substr(begin, end - begin + 1);
+	return s.substr(begin, end - begin + 1);
 }
 
 
@@ -135,7 +135,7 @@ void update_source_file(std::string const &prefix, std::string const &file_name,
 
 	// std::experimental::filesystem::create_directories(path);
 	string command_line = "mkdir -p " + path;
-	if (system(command_line.c_str()) != 0) throw std::runtime_error("ERROR: Command \"" + command_line + "\" failed");
+	if( system(command_line.c_str()) != 0 ) throw std::runtime_error("ERROR: Command \"" + command_line + "\" failed");
 
 	string full_file_name = prefix + '/' + file_name;
 	std::ifstream f(full_file_name);
@@ -240,7 +240,7 @@ string template_argument_to_string(clang::TemplateArgument const &t)
 	t.print(Policy, s, true);
 #endif
 
-    string r = s.str();
+	string r = s.str();
 
 	// // simplify result if argument is a small number, taking care of cases like 1L or 1UL
 	// if( r.size() < 5 and std::isdigit(r[0]) ) {
@@ -256,7 +256,7 @@ string template_argument_to_string(clang::TemplateArgument const &t)
 string line_number(NamedDecl const *decl)
 {
 	bool l_skip_line_number = Config::get().skip_line_number;
-	if (l_skip_line_number) return std::string("");
+	if( l_skip_line_number ) return std::string("");
 	ASTContext &ast_context(decl->getASTContext());
 	SourceManager &sm(ast_context.getSourceManager());
 


### PR DESCRIPTION
Following up on https://github.com/RosettaCommons/binder/pull/329#issuecomment-3133589706

This PR is just the result of calling `clang-format -i *.hpp` and `clang-format -i *.cpp` in the `source` directory, with clang format v18.1.3 on Ubuntu 24.