### PR TITLE
Allow multiple add ons for the same class or namespace

### DIFF
--- a/source/class.cpp
+++ b/source/class.cpp
@@ -1407,8 +1407,12 @@ void ClassBinder::bind(Context &context)
 
 	c += bind_repr(context, Config::get());
 
-	std::map<string, string> const &external_add_on_binders = Config::get().add_on_binders();
-	if( external_add_on_binders.count(qualified_name_without_template) ) c += "\n\t{}(cl);\n"_format(external_add_on_binders.at(qualified_name_without_template));
+	std::map<string, std::vector<string>> const &external_add_on_binders = Config::get().add_on_binders();
+	if( external_add_on_binders.count(qualified_name_without_template) ) {
+		for( auto const& add_on : external_add_on_binders.at(qualified_name_without_template) ) {
+			c += "\n\t{}(cl);\n"_format(add_on);
+		}
+	}
 
 	c += bind_nested_classes(context);
 

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -196,7 +196,7 @@ void Config::read(string const &file_name)
 
 			if( bind ) {
 				auto binder_function = split_in_two(name, "Invalid line for add_on_binder specification! Must be: name_of_type + <space or tab> + name_of_binder. Got: " + line);
-				add_on_binders_[binder_function.first] = trim(binder_function.second);
+				add_on_binders_[binder_function.first].push_back(trim(binder_function.second));
 			}
 		}
 		else if( token == _binder_for_namespace_ ) {
@@ -210,7 +210,7 @@ void Config::read(string const &file_name)
 
 			if( bind ) {
 				auto binder_function = split_in_two(name, "Invalid line for add_on_binder_for_namespace specification! Must be: name_of_type + <space or tab> + name_of_binder. Got: " + line);
-				add_on_binder_for_namespaces_[binder_function.first] = trim(binder_function.second);
+				add_on_binder_for_namespaces_[binder_function.first].push_back(trim(binder_function.second));
 			}
 		} else if ( token == _field_ ) {
 

--- a/source/config.hpp
+++ b/source/config.hpp
@@ -38,8 +38,10 @@ class Config
 	}
 
 private:
-	std::map<string, string> binders_, add_on_binders_;
-	std::map<string, string> binder_for_namespaces_, add_on_binder_for_namespaces_, custom_trampoline_functions_;
+
+	std::map<string, string> binders_, binder_for_namespaces_;
+	std::map<string, std::vector<string>> add_on_binders_, add_on_binder_for_namespaces_;
+	std::map<string, string> custom_trampoline_functions_;
 
 	std::map<string, std::vector<string> > class_includes_, namespace_includes_;
 
@@ -69,10 +71,10 @@ public:
 	std::vector<string> buffer_protocols, module_local_namespaces_to_add, module_local_namespaces_to_skip, smart_held_classes;
 
 	std::map<string, string> const &binders() const { return binders_; }
-	std::map<string, string> const &add_on_binders() const { return add_on_binders_; }
+	std::map<string, std::vector<string>> const &add_on_binders() const { return add_on_binders_; }
 
 	std::map<string, string> const &binder_for_namespaces() const { return binder_for_namespaces_; }
-	std::map<string, string> const &add_on_binder_for_namespaces() const { return add_on_binder_for_namespaces_; }
+	std::map<string, std::vector<string>> const &add_on_binder_for_namespaces() const { return add_on_binder_for_namespaces_; }
 
 	std::set<string> python_builtins, not_python_builtins;
 

--- a/source/context.cpp
+++ b/source/context.cpp
@@ -387,9 +387,11 @@ void Context::generate(Config const &config)
 			skip = true;
 		}
 
-		std::map<string, string> const &add_on_binder_for_namespaces = Config::get().add_on_binder_for_namespaces();
-		if( add_on_binder_for_namespaces.count(namespace_) and code.empty() ) {
-			if( namespace_entrance[namespace_] == 0 ) code += "\n\t{}(M(\"{}\"));\n"_format(add_on_binder_for_namespaces.at(namespace_), namespace_);
+		std::map<string, std::vector<string>> const &add_on_binder_for_namespaces = Config::get().add_on_binder_for_namespaces();
+		if( add_on_binder_for_namespaces.count(namespace_) and code.empty() and namespace_entrance[namespace_] == 0 ) {
+			for( auto const& add_on : add_on_binder_for_namespaces.at(namespace_) ) {
+				code += "\n\t{}(M(\"{}\"));\n"_format(add_on, namespace_);
+			}
 		}
 
 		for( ; code.size() < config.maximum_file_length and i < binders.size() and namespace_ == namespace_from_named_decl(binders[i]->named_decl()); ++i ) {


### PR DESCRIPTION
Currently, when specifying the `add_on_binder` or `add_on_binder_for_namespace` tokens multiple times, later ones silently replace previous ones, which is unexpected. This PR extends this to capture multiple add ons, which can be useful to break them down into smaller pieces.