### PR TITLE
Update MacOS runner for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
              ctest . --output-on-failure
 
   compilejobOSX:
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     name: Binder_on_OSX
     steps:
     - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
              ctest . --output-on-failure
 
   compilejobOSX:
-    runs-on: macos-13
+    runs-on: macos-26-intel
     name: Binder_on_OSX
     steps:
     - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
              ctest . --output-on-failure
 
   compilejobOSX:
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
     name: Binder_on_OSX
     steps:
     - name: Checkout


### PR DESCRIPTION
`macos-13` runner is [deprecated](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), the latest MacOS x86 runner is `macos-26-intel`.